### PR TITLE
Honor the host and port settings in the YAML config

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -31,6 +31,17 @@ func NewServer(cfg *config.Config) *Server {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// If the host and port are set in config.yaml, and they weren't set in the
+	// environment, update the environment level config accordingly, which is
+	// the config used to start the server.
+	if cfg.Host == "" {
+		cfg.Host = ac.Host
+	}
+	if cfg.Port == 0 {
+		cfg.Port = ac.Port
+	}
+
 	mw := []wish.Middleware{
 		bm.Middleware(tui.SessionHandler(ac)),
 		gm.Middleware(cfg.RepoPath, ac),


### PR DESCRIPTION
Note that precedence will be given to the environment variables.

Fixes #38.