### PR TITLE
Add basic support for light backgrounds

### DIFF
--- a/internal/tui/bubbles/repo/bubble.go
+++ b/internal/tui/bubbles/repo/bubble.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/ansi"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/soft-serve/internal/git"
 	"github.com/charmbracelet/soft-serve/internal/tui/style"
@@ -20,6 +21,15 @@ const (
 	glamourMaxWidth  = 120
 	repoNameMaxWidth = 32
 )
+
+var glamourStyle = func() ansi.StyleConfig {
+	noColor := ""
+	s := glamour.DarkStyleConfig
+	s.Document.StylePrimitive.Color = &noColor
+	s.CodeBlock.Chroma.Text.Color = &noColor
+	s.CodeBlock.Chroma.Name.Color = &noColor
+	return s
+}()
 
 type ErrMsg struct {
 	Error error
@@ -203,7 +213,7 @@ func (b *Bubble) glamourize(md string) (string, error) {
 		w = glamourMaxWidth
 	}
 	tr, err := glamour.NewTermRenderer(
-		glamour.WithStandardStyle("dark"),
+		glamour.WithStyles(glamourStyle),
 		glamour.WithWordWrap(w),
 	)
 

--- a/internal/tui/style/style.go
+++ b/internal/tui/style/style.go
@@ -65,7 +65,6 @@ func DefaultStyles() *Styles {
 		SetString(">")
 
 	s.MenuItem = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252")).
 		PaddingLeft(2)
 
 	s.SelectedMenuItem = lipgloss.NewStyle().
@@ -106,8 +105,7 @@ func DefaultStyles() *Styles {
 	}
 
 	s.RepoTitle = lipgloss.NewStyle().
-		Padding(0, 2).
-		Foreground(lipgloss.Color("252"))
+		Padding(0, 2)
 
 	s.RepoTitleBox = lipgloss.NewStyle().
 		BorderStyle(s.RepoTitleBorder).


### PR DESCRIPTION
This update addresses basic readability issues on light backgrounds.

While it's sufficient for most cases, there are a few colors with respect to source code that can be improved. Those should be handled upstream in a new [Glamour](https://github.com/charmbracelet/glamour) stylesheet.

Fixes #37.