### PR TITLE
Clarify that host 'n port settings in config are for display purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The Soft Serve configuration is simple and straightforward:
 # The name of the server to show in the TUI.
 name: Soft Serve
 
-# The host and port to listen on. Defaults to 0.0.0.0:23231.
+# The host and port to display in the TUI. You may want to change this if your
+# server is accessible from a different host and/or port that what it's
+# actually listening on (for example, if it's behind a reverse proxy).
 host: localhost
 port: 23231
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -5,7 +5,9 @@ const defaultReadme = "# Soft Serve\n\n Welcome! You can configure your Soft Ser
 const defaultConfig = `# The name of the server to show in the TUI.
 name: Soft Serve
 
-# The host and port to listen on. Defaults to 0.0.0.0:23231.
+# The host and port to display in the TUI. You may want to change this if your
+# server is accessible from a different host and/or port that what it's
+# actually listening on (for example, if it's behind a reverse proxy).
 host: %s
 port: %d
 

--- a/server/server.go
+++ b/server/server.go
@@ -32,17 +32,6 @@ func NewServer(cfg *config.Config) *Server {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// If the host and port are set in config.yaml, and they weren't set in the
-	// environment, update the environment level config accordingly, which is
-	// the config used to start the server.
-	if cfg.Host == "" {
-		cfg.Host = ac.Host
-	}
-	if cfg.Port == 0 {
-		cfg.Port = ac.Port
-	}
-
 	mw := []wish.Middleware{
 		bm.Middleware(tui.SessionHandler(ac)),
 		gm.Middleware(cfg.RepoPath, ac),


### PR DESCRIPTION
Resolves #38.