### PR TITLE
Update footer image in release template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,7 +79,8 @@ release:
   footer: |
     * * *
     Thoughts? Questions? We love hearing from you. Feel free to reach out on [Twitter](https://twitter.com/charmcli) or [The Fediverse](https://mastodon.technology/@charm).
-    <a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge-unrounded.jpg" width="400"></a>
+
+    <a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg?1" width="400"></a>
 
 dockers:
   - image_templates:


### PR DESCRIPTION
This tiny update updates the image in the footer added to releases by `goreleaser`.