### PR TITLE
Use glamour to render markdown files and fix error when switching refs

### DIFF
--- a/internal/tui/bubble.go
+++ b/internal/tui/bubble.go
@@ -162,7 +162,7 @@ func (b Bubble) footerView() string {
 		h = []gittypes.HelpEntry{
 			{"tab", "section"},
 		}
-		if box, ok := b.boxes[b.activeBox].(gittypes.HelpableBubble); ok {
+		if box, ok := b.boxes[b.activeBox].(gittypes.BubbleHelper); ok {
 			help := box.Help()
 			for _, he := range help {
 				h = append(h, he)

--- a/internal/tui/bubbles/git/about/bubble.go
+++ b/internal/tui/bubbles/git/about/bubble.go
@@ -78,9 +78,7 @@ func (b *Bubble) View() string {
 }
 
 func (b *Bubble) Help() []types.HelpEntry {
-	return []types.HelpEntry{
-		{"f/b", "pgup/pgdown"},
-	}
+	return nil
 }
 
 func (b *Bubble) setupCmd() tea.Msg {

--- a/internal/tui/bubbles/git/about/bubble.go
+++ b/internal/tui/bubbles/git/about/bubble.go
@@ -52,7 +52,7 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		b.readmeViewport.Viewport.SetContent(md)
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "A":
+		case "R":
 			b.GotoTop()
 		}
 	}

--- a/internal/tui/bubbles/git/bubble.go
+++ b/internal/tui/bubbles/git/bubble.go
@@ -85,22 +85,13 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 		}
+	case refs.RefMsg:
+		b.state = treePage
 	}
 	m, cmd := b.boxes[b.state].Update(msg)
 	b.boxes[b.state] = m
 	if cmd != nil {
 		cmds = append(cmds, cmd)
-	}
-
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "enter":
-			if b.state == refsPage {
-				b.state = treePage
-				cmds = append(cmds, b.boxes[b.state].Init())
-			}
-		}
 	}
 	return b, tea.Batch(cmds...)
 }

--- a/internal/tui/bubbles/git/bubble.go
+++ b/internal/tui/bubbles/git/bubble.go
@@ -65,13 +65,13 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if b.repo.Name() != "config" {
 			switch msg.String() {
-			case "r", "R":
+			case "R":
 				b.state = aboutPage
-			case "b", "B":
+			case "B":
 				b.state = refsPage
-			case "c", "C":
+			case "C":
 				b.state = logPage
-			case "f", "F":
+			case "F":
 				b.state = treePage
 			}
 		}
@@ -98,12 +98,12 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (b *Bubble) Help() []types.HelpEntry {
 	h := []types.HelpEntry{}
-	h = append(h, b.boxes[b.state].(types.HelpableBubble).Help()...)
+	h = append(h, b.boxes[b.state].(types.BubbleHelper).Help()...)
 	if b.repo.Name() != "config" {
-		h = append(h, types.HelpEntry{"r", "readme"})
-		h = append(h, types.HelpEntry{"f", "files"})
-		h = append(h, types.HelpEntry{"c", "commits"})
-		h = append(h, types.HelpEntry{"b", "branches/tags"})
+		h = append(h, types.HelpEntry{"R", "readme"})
+		h = append(h, types.HelpEntry{"F", "files"})
+		h = append(h, types.HelpEntry{"C", "commits"})
+		h = append(h, types.HelpEntry{"B", "branches"})
 	}
 	return h
 }

--- a/internal/tui/bubbles/git/bubble.go
+++ b/internal/tui/bubbles/git/bubble.go
@@ -63,15 +63,17 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cmds := make([]tea.Cmd, 0)
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "A":
-			b.state = aboutPage
-		case "R":
-			b.state = refsPage
-		case "L":
-			b.state = logPage
-		case "T":
-			b.state = treePage
+		if b.repo.Name() != "config" {
+			switch msg.String() {
+			case "r", "R":
+				b.state = aboutPage
+			case "b", "B":
+				b.state = refsPage
+			case "c", "C":
+				b.state = logPage
+			case "f", "F":
+				b.state = treePage
+			}
 		}
 	case tea.WindowSizeMsg:
 		b.width = msg.Width
@@ -105,21 +107,12 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (b *Bubble) Help() []types.HelpEntry {
 	h := []types.HelpEntry{}
-	if b.state != treePage {
-		h = append(h, types.HelpEntry{"↑/↓", "navigate"})
-	}
 	h = append(h, b.boxes[b.state].(types.HelpableBubble).Help()...)
-	if b.state != aboutPage {
-		h = append(h, types.HelpEntry{"A", "about"})
-	}
-	if b.state != refsPage {
-		h = append(h, types.HelpEntry{"R", "refs"})
-	}
-	if b.state != logPage {
-		h = append(h, types.HelpEntry{"L", "log"})
-	}
-	if b.state != treePage {
-		h = append(h, types.HelpEntry{"T", "tree"})
+	if b.repo.Name() != "config" {
+		h = append(h, types.HelpEntry{"r", "readme"})
+		h = append(h, types.HelpEntry{"f", "files"})
+		h = append(h, types.HelpEntry{"c", "commits"})
+		h = append(h, types.HelpEntry{"b", "branches/tags"})
 	}
 	return h
 }

--- a/internal/tui/bubbles/git/log/bubble.go
+++ b/internal/tui/bubbles/git/log/bubble.go
@@ -99,8 +99,8 @@ type Bubble struct {
 	error          types.ErrMsg
 }
 
-func NewBubble(repo types.Repo, style *style.Styles, width, widthMargin, height, heightMargin int) *Bubble {
-	l := list.New([]list.Item{}, itemDelegate{style}, width-widthMargin, height-heightMargin)
+func NewBubble(repo types.Repo, styles *style.Styles, width, widthMargin, height, heightMargin int) *Bubble {
+	l := list.New([]list.Item{}, itemDelegate{styles}, width-widthMargin, height-heightMargin)
 	l.SetShowFilter(false)
 	l.SetShowHelp(false)
 	l.SetShowPagination(false)
@@ -115,7 +115,7 @@ func NewBubble(repo types.Repo, style *style.Styles, width, widthMargin, height,
 			Viewport: &viewport.Model{},
 		},
 		repo:         repo,
-		style:        style,
+		style:        styles,
 		state:        logState,
 		width:        width,
 		widthMargin:  widthMargin,

--- a/internal/tui/bubbles/git/log/bubble.go
+++ b/internal/tui/bubbles/git/log/bubble.go
@@ -140,16 +140,7 @@ func (b *Bubble) updateItems() tea.Cmd {
 }
 
 func (b *Bubble) Help() []types.HelpEntry {
-	switch b.state {
-	case logState:
-		return []types.HelpEntry{
-			{"enter", "select"},
-		}
-	default:
-		return []types.HelpEntry{
-			{"esc", "back"},
-		}
-	}
+	return nil
 }
 
 func (b *Bubble) GotoTop() {

--- a/internal/tui/bubbles/git/log/bubble.go
+++ b/internal/tui/bubbles/git/log/bubble.go
@@ -167,7 +167,7 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "L":
+		case "C":
 			b.state = logState
 			b.list.Select(0)
 			cmds = append(cmds, b.updateItems())

--- a/internal/tui/bubbles/git/refs/bubble.go
+++ b/internal/tui/bubbles/git/refs/bubble.go
@@ -75,8 +75,8 @@ type Bubble struct {
 	heightMargin int
 }
 
-func NewBubble(repo types.Repo, style *style.Styles, width, widthMargin, height, heightMargin int) *Bubble {
-	l := list.NewModel([]list.Item{}, itemDelegate{style}, width-widthMargin, height-heightMargin)
+func NewBubble(repo types.Repo, styles *style.Styles, width, widthMargin, height, heightMargin int) *Bubble {
+	l := list.NewModel([]list.Item{}, itemDelegate{styles}, width-widthMargin, height-heightMargin)
 	l.SetShowFilter(false)
 	l.SetShowHelp(false)
 	l.SetShowPagination(false)
@@ -86,7 +86,7 @@ func NewBubble(repo types.Repo, style *style.Styles, width, widthMargin, height,
 	l.DisableQuitKeybindings()
 	b := &Bubble{
 		repo:         repo,
-		style:        style,
+		style:        styles,
 		width:        width,
 		height:       height,
 		widthMargin:  widthMargin,

--- a/internal/tui/bubbles/git/refs/bubble.go
+++ b/internal/tui/bubbles/git/refs/bubble.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
+type RefMsg = *plumbing.Reference
+
 type item struct {
 	*plumbing.Reference
 }
@@ -95,8 +97,11 @@ func NewBubble(repo types.Repo, style *style.Styles, width, widthMargin, height,
 	return b
 }
 
-func (b *Bubble) SetBranch(ref *plumbing.Reference) {
-	b.repo.SetReference(ref)
+func (b *Bubble) SetBranch(ref *plumbing.Reference) (tea.Model, tea.Cmd) {
+	return b, func() tea.Msg {
+		b.repo.SetReference(ref)
+		return RefMsg(ref)
+	}
 }
 
 func (b *Bubble) Init() tea.Cmd {
@@ -155,7 +160,7 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter", "right", "l":
 			if b.list.Index() >= 0 {
 				ref := b.list.SelectedItem().(item).Reference
-				b.SetBranch(ref)
+				return b.SetBranch(ref)
 			}
 		}
 	}

--- a/internal/tui/bubbles/git/refs/bubble.go
+++ b/internal/tui/bubbles/git/refs/bubble.go
@@ -110,9 +110,7 @@ func (b *Bubble) SetSize(width, height int) {
 }
 
 func (b *Bubble) Help() []types.HelpEntry {
-	return []types.HelpEntry{
-		{"enter", "select"},
-	}
+	return nil
 }
 
 func (b *Bubble) updateItems() tea.Cmd {

--- a/internal/tui/bubbles/git/refs/bubble.go
+++ b/internal/tui/bubbles/git/refs/bubble.go
@@ -155,7 +155,7 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "R":
+		case "B":
 			cmds = append(cmds, b.updateItems())
 		case "enter", "right", "l":
 			if b.list.Index() >= 0 {

--- a/internal/tui/bubbles/git/tree/bubble.go
+++ b/internal/tui/bubbles/git/tree/bubble.go
@@ -220,7 +220,7 @@ func (b *Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "T":
+		case "F":
 			return b, b.reset()
 		case "enter", "right", "l":
 			if b.state == treeState {

--- a/internal/tui/bubbles/git/tree/bubble.go
+++ b/internal/tui/bubbles/git/tree/bubble.go
@@ -130,8 +130,8 @@ type Bubble struct {
 	lastSelected []int
 }
 
-func NewBubble(repo types.Repo, style *style.Styles, width, widthMargin, height, heightMargin int) *Bubble {
-	l := list.New([]list.Item{}, itemDelegate{style}, width-widthMargin, height-heightMargin)
+func NewBubble(repo types.Repo, styles *style.Styles, width, widthMargin, height, heightMargin int) *Bubble {
+	l := list.New([]list.Item{}, itemDelegate{styles}, width-widthMargin, height-heightMargin)
 	l.SetShowFilter(false)
 	l.SetShowHelp(false)
 	l.SetShowPagination(false)
@@ -146,7 +146,7 @@ func NewBubble(repo types.Repo, style *style.Styles, width, widthMargin, height,
 			Viewport: &viewport.Model{},
 		},
 		repo:         repo,
-		style:        style,
+		style:        styles,
 		width:        width,
 		height:       height,
 		widthMargin:  widthMargin,
@@ -330,12 +330,22 @@ func (b *Bubble) renderFile(m fileMsg) string {
 			Code:     c,
 			Language: lang,
 		}
-		r := strings.Builder{}
-		err := formatter.Render(&r, types.RenderCtx)
-		if err != nil {
-			s.WriteString(err.Error())
+		if lang == "markdown" {
+			w := b.width - b.widthMargin - b.style.RepoBody.GetHorizontalFrameSize()
+			md, err := types.Glamourize(w, c)
+			if err != nil {
+				s.WriteString(err.Error())
+			} else {
+				s.WriteString(md)
+			}
 		} else {
-			s.WriteString(r.String())
+			r := strings.Builder{}
+			err := formatter.Render(&r, types.RenderCtx)
+			if err != nil {
+				s.WriteString(err.Error())
+			} else {
+				s.WriteString(r.String())
+			}
 		}
 	}
 	return b.style.TreeFileContent.Copy().Width(b.width - b.widthMargin).Render(s.String())

--- a/internal/tui/bubbles/git/tree/bubble.go
+++ b/internal/tui/bubbles/git/tree/bubble.go
@@ -175,14 +175,7 @@ func (b *Bubble) SetSize(width, height int) {
 }
 
 func (b *Bubble) Help() []types.HelpEntry {
-	h := []types.HelpEntry{}
-	switch b.state {
-	case errorState:
-		h = append(h, types.HelpEntry{"esc", "back"})
-	default:
-		h = append(h, types.HelpEntry{"←/↑/→/↓", "navigate"})
-	}
-	return h
+	return nil
 }
 
 func (b *Bubble) updateItems() tea.Cmd {

--- a/internal/tui/bubbles/git/types/formatter.go
+++ b/internal/tui/bubbles/git/types/formatter.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/charmbracelet/glamour"
 	gansi "github.com/charmbracelet/glamour/ansi"
+	"github.com/muesli/reflow/wrap"
 	"github.com/muesli/termenv"
 )
 
@@ -33,4 +34,30 @@ func NewRenderCtx(worldwrap int) gansi.RenderContext {
 		Styles:       DefaultStyles(),
 		WordWrap:     worldwrap,
 	})
+}
+
+func Glamourize(w int, md string) (string, error) {
+	if w > GlamourMaxWidth {
+		w = GlamourMaxWidth
+	}
+	tr, err := glamour.NewTermRenderer(
+		glamour.WithStyles(DefaultStyles()),
+		glamour.WithWordWrap(w),
+	)
+
+	if err != nil {
+		return "", err
+	}
+	mdt, err := tr.Render(md)
+	if err != nil {
+		return "", err
+	}
+	// For now, hard-wrap long lines in Glamour that would otherwise break the
+	// layout when wrapping. This may be due to #43 in Reflow, which has to do
+	// with a bug in the way lines longer than the given width are wrapped.
+	//
+	//     https://github.com/muesli/reflow/issues/43
+	//
+	// TODO: solve this upstream in Glamour/Reflow.
+	return wrap.String(mdt, w), nil
 }

--- a/internal/tui/bubbles/git/types/help.go
+++ b/internal/tui/bubbles/git/types/help.go
@@ -1,6 +1,6 @@
 package types
 
-type HelpableBubble interface {
+type BubbleHelper interface {
 	Help() []HelpEntry
 }
 


### PR DESCRIPTION
* Use glamour to render markdown files otherwise default to chroma
* Fix error when switching refs
* Change git tui navigation keys to R readme, F files, B branches, and C commits