### PR TITLE
Custom readme path

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ anon-access: read-write
 # You can grant read-only access to users without private keys.
 allow-keyless: false
 
-# Which repos should appear in the menu?
+# Customize repos in the menu
 repos:
   - name: Home
     repo: config
@@ -107,6 +107,7 @@ repos:
     repo: my-public-repo
     private: false
     note: "A publicly-accessible repo"
+    readme: docs/README.md
   - name: Example Private Repo
     repo: my-private-repo
     private: true

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 )
 
 require (
+	github.com/gobwas/glob v0.2.3
 	github.com/muesli/mango v0.1.0
 	github.com/muesli/roff v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2Su
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -19,13 +19,13 @@ anon-access: %s
 # will be accepted.
 allow-keyless: false
 
-# Customize repo display in the menu. Only repos in this list will appear in
-# the TUI.
+# Customize repo display in the menu.
 repos:
   - name: Home
     repo: config
     private: true
     note: "Configuration and content repo for this server"
+    readme: README.md
 `
 
 const hasKeyUserConfig = `

--- a/internal/config/git.go
+++ b/internal/config/git.go
@@ -18,6 +18,15 @@ func (cfg *Config) Push(repo string, pk ssh.PublicKey) {
 		if cfg.Cfg.Callbacks != nil {
 			cfg.Cfg.Callbacks.Push(repo)
 		}
+		r, err := cfg.Source.GetRepo(repo)
+		if err != nil {
+			log.Printf("error getting repo after push: %s", err)
+			return
+		}
+		err = r.UpdateServerInfo()
+		if err != nil {
+			log.Printf("error updating server info after push: %s", err)
+		}
 	}()
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -385,3 +386,9 @@ func (r *Repo) LatestTree(path string) (*object.Tree, error) {
 	return r.Tree(r.head, path)
 }
 
+// UpdateServerInfo updates the server info for the repository.
+func (r *Repo) UpdateServerInfo() error {
+	cmd := exec.Command("git", "update-server-info")
+	cmd.Dir = r.path
+	return cmd.Run()
+}

--- a/internal/tui/bubbles/git/about/bubble.go
+++ b/internal/tui/bubbles/git/about/bubble.go
@@ -8,6 +8,7 @@ import (
 	vp "github.com/charmbracelet/soft-serve/internal/tui/bubbles/git/viewport"
 	"github.com/charmbracelet/soft-serve/internal/tui/style"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/muesli/reflow/wrap"
 )
 
 type Bubble struct {
@@ -92,7 +93,18 @@ func (b *Bubble) glamourize() (string, error) {
 	if rm == "" {
 		return b.styles.AboutNoReadme.Render("No readme found."), nil
 	}
-	return types.Glamourize(w, rm)
+	f, err := types.RenderFile(b.repo.GetReadmePath(), rm, w)
+	if err != nil {
+		return "", err
+	}
+	// For now, hard-wrap long lines in Glamour that would otherwise break the
+	// layout when wrapping. This may be due to #43 in Reflow, which has to do
+	// with a bug in the way lines longer than the given width are wrapped.
+	//
+	//     https://github.com/muesli/reflow/issues/43
+	//
+	// TODO: solve this upstream in Glamour/Reflow.
+	return wrap.String(f, w), nil
 }
 
 func (b *Bubble) setupCmd() tea.Msg {

--- a/internal/tui/bubbles/git/tree/bubble.go
+++ b/internal/tui/bubbles/git/tree/bubble.go
@@ -7,11 +7,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
-	gansi "github.com/charmbracelet/glamour/ansi"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/soft-serve/internal/tui/bubbles/git/refs"
 	"github.com/charmbracelet/soft-serve/internal/tui/bubbles/git/types"
@@ -336,31 +334,12 @@ func (b *Bubble) renderFile(m fileMsg) string {
 	if len(strings.Split(c, "\n")) > types.MaxDiffLines {
 		s.WriteString(types.ErrFileTooLarge.Error())
 	} else {
-		lexer := lexers.Match(b.path)
-		lang := ""
-		if lexer != nil && lexer.Config() != nil {
-			lang = lexer.Config().Name
-		}
-		formatter := &gansi.CodeBlockElement{
-			Code:     c,
-			Language: lang,
-		}
-		if lang == "markdown" {
-			w := b.width - b.widthMargin - b.style.RepoBody.GetHorizontalFrameSize()
-			md, err := types.Glamourize(w, c)
-			if err != nil {
-				s.WriteString(err.Error())
-			} else {
-				s.WriteString(md)
-			}
+		w := b.width - b.widthMargin - b.style.RepoBody.GetHorizontalFrameSize()
+		f, err := types.RenderFile(b.path, m.content, w)
+		if err != nil {
+			s.WriteString(err.Error())
 		} else {
-			r := strings.Builder{}
-			err := formatter.Render(&r, types.RenderCtx)
-			if err != nil {
-				s.WriteString(err.Error())
-			} else {
-				s.WriteString(r.String())
-			}
+			s.WriteString(f)
 		}
 	}
 	return b.style.TreeFileContent.Copy().Width(b.width - b.widthMargin).Render(s.String())

--- a/internal/tui/bubbles/git/types/git.go
+++ b/internal/tui/bubbles/git/types/git.go
@@ -14,6 +14,7 @@ type Repo interface {
 	SetHEAD(*plumbing.Reference) error
 	GetReferences() []*plumbing.Reference
 	GetReadme() string
+	GetReadmePath() string
 	GetCommits(*plumbing.Reference) (Commits, error)
 	Repository() *git.Repository
 	Tree(*plumbing.Reference, string) (*object.Tree, error)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -1,9 +1,7 @@
 package tui
 
 import (
-	"bytes"
 	"fmt"
-	"text/template"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -102,13 +100,6 @@ func (b *Bubble) newMenuEntry(name string, rn string) (MenuEntry, error) {
 	if err != nil {
 		return me, err
 	}
-	if rn == "config" {
-		md, err := templatize(r.Readme, b.config)
-		if err != nil {
-			return me, err
-		}
-		r.Readme = md
-	}
 	boxLeftWidth := b.styles.Menu.GetWidth() + b.styles.Menu.GetHorizontalFrameSize()
 	// TODO: also send this along with a tea.WindowSizeMsg
 	var heightMargin = lipgloss.Height(b.headerView()) +
@@ -124,17 +115,4 @@ func (b *Bubble) newMenuEntry(name string, rn string) (MenuEntry, error) {
 	}
 	me.bubble = rb
 	return me, nil
-}
-
-func templatize(mdt string, tmpl interface{}) (string, error) {
-	t, err := template.New("readme").Parse(mdt)
-	if err != nil {
-		return "", err
-	}
-	buf := &bytes.Buffer{}
-	err = t.Execute(buf, tmpl)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
 }


### PR DESCRIPTION
* Optionally specify per repo readme file path in config
* Default to "README*" glob and choose the first glob match
* Refactor code and move stuff around
* UpdateServerInfo on repo push