### PR TITLE
Run soft-serve as non-root on port 22

### DIFF
--- a/examples/non-root/main.go
+++ b/examples/non-root/main.go
@@ -1,0 +1,65 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/charmbracelet/soft-serve/config"
+	"github.com/charmbracelet/soft-serve/server"
+)
+
+const (
+	port = 22
+	gid  = 1000
+	uid  = 1000
+)
+
+var (
+	addr = fmt.Sprintf(":%d", port)
+)
+
+func main() {
+	// To listen on port 22 we need root privileges
+	ls, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("Can't listen: %s", err)
+	}
+	// We don't need root privileges any more
+	if err := syscall.Setgid(gid); err != nil {
+		log.Fatalf("Setgid error: %s", err)
+	}
+	if err := syscall.Setuid(uid); err != nil {
+		log.Fatalf("Setuid error: %s", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.Port = port
+	s := server.NewServer(cfg)
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	log.Printf("Starting SSH server on %s:%d", cfg.BindAddr, cfg.Port)
+	go func() {
+		if err := s.Serve(ls); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	<-done
+
+	log.Printf("Stopping SSH server on %s:%d", cfg.BindAddr, cfg.Port)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() { cancel() }()
+	if err := s.Shutdown(ctx); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,7 +97,12 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 	} else {
 		displayHost = host
 	}
-	yamlConfig := fmt.Sprintf(defaultConfig, displayHost, port, anonAccess)
+	yamlConfig := fmt.Sprintf(defaultConfig,
+		displayHost,
+		port,
+		anonAccess,
+		len(pks) == 0,
+	)
 	if len(pks) == 0 {
 		yamlUsers = defaultUserConfig
 	} else {
@@ -186,6 +191,7 @@ func (cfg *Config) createDefaultConfigRepo(yaml string) error {
 	rs := cfg.Source
 	err := rs.LoadRepo(cn)
 	if os.IsNotExist(err) {
+		log.Printf("creating default config repo %s", cn)
 		repo, err := ggit.PlainInit(rp, true)
 		if err != nil {
 			return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
@@ -223,12 +224,14 @@ func (cfg *Config) createDefaultConfigRepo(yaml string) error {
 		if err != nil {
 			return err
 		}
+		author := &object.Signature{
+			Name:  "Soft Serve Server",
+			Email: "vt100@charm.sh",
+			When:  time.Now(),
+		}
 		_, err = wt.Commit("Default init", &ggit.CommitOptions{
-			All: true,
-			Author: &object.Signature{
-				Name:  "Soft Serve Server",
-				Email: "vt100@charm.sh",
-			},
+			All:    true,
+			Author: author,
 		})
 		if err != nil {
 			return err

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -17,7 +17,7 @@ anon-access: %s
 
 # You can grant read-only access to users without private keys. Any password
 # will be accepted.
-allow-keyless: false
+allow-keyless: %t
 
 # Customize repo display in the menu.
 repos:

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -201,7 +201,6 @@ func (rs *RepoSource) LoadRepo(name string) error {
 	rp := filepath.Join(rs.Path, name)
 	r, err := rs.open(rp)
 	if err != nil {
-		log.Printf("error opening repository %s: %s", name, err)
 		return err
 	}
 	rs.repos[name] = r

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 
 	"github.com/charmbracelet/soft-serve/config"
 	appCfg "github.com/charmbracelet/soft-serve/internal/config"
@@ -67,6 +68,11 @@ func (srv *Server) Reload() error {
 // Start starts the SSH server.
 func (srv *Server) Start() error {
 	return srv.SSHServer.ListenAndServe()
+}
+
+// Serve serves the SSH server using the provided listener.
+func (srv *Server) Serve(l net.Listener) error {
+	return srv.SSHServer.Serve(l)
 }
 
 // Shutdown lets the server gracefully shutdown.


### PR DESCRIPTION
* Fix default config repo first commit time
* Fix allowing keyless when no pk provided
* Expose ssh server `Serve()` to listen on a custom net.Listener
* Add running soft-serve as a non root on port 22 example

Closes: https://github.com/charmbracelet/soft-serve/issues/116

EDIT: to test this out `go build ./examples/setuid && sudo ./setuid`