### PR TITLE
Fix GIF on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ Soft Serve
 
 A tasty, self-hostable Git server for the command line. 🍦
 
-<img src="https://stuff.charm.sh/soft-serve/soft-serve-demo.gif?0" width="750" alt="Soft Serve screencast">
+<picture>
+  <source media="(max-width: 750px)" srcset="https://stuff.charm.sh/soft-serve/soft-serve-demo.gif?0">
+  <source media="(min-width: 750px)" width="750" srcset="https://stuff.charm.sh/soft-serve/soft-serve-demo.gif?0">
+  <img src="https://stuff.charm.sh/soft-serve/soft-serve-demo.gif?0" alt="Soft Serve screencast">
+</picture>
 
 * Configure with `git`
 * Create repos on demand with `git push`


### PR DESCRIPTION
This PR fixes the GIF rendering on small mobile screens and makes the GIF 100%
of the width unless the screen is larger than 750px in which case the GIF is
set to 750px as the max-width.
