### PR TITLE
fix: misleading authorized users comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,11 @@ repos:
     note: "A private repo"
 
 # Authorized users. Admins have full access to all repos. Regular users
-# can read all repos and push to their collab-repos.
+# can read public repos and push to their collab-repos.
+
+# Authorized users. Admins have full access to all repos. Private repos are only
+# accessible by admins and collab users. Regular users can read public repos
+# based on your anon-access setting.
 users:
   - name: Beatrice
     admin: true

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -30,8 +30,9 @@ repos:
 
 const hasKeyUserConfig = `
 
-# Authorized users. Admins have full access to all repos. Users can read all
-# repos and push to their collab-repos.
+# Authorized users. Admins have full access to all repos. Private repos are only
+# accessible by admins and collab users. Regular users can read public repos
+# based on your anon-access setting.
 users:
   - name: Admin
     admin: true


### PR DESCRIPTION
Private repos can be accessed by admins and collab users. All other users can read public repos based on the anon-access setting.

Fixes: https://github.com/charmbracelet/soft-serve/issues/165