### PR TITLE
Improve port forwarding wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ name: Soft Serve
 
 # The host and port to display in the TUI. You may want to change this if your
 # server is accessible from a different host and/or port that what it's
-# actually listening on (for example, if it's behind a reverse proxy).
+# actually listening on (for example, if it's behind a port forwarding router).
 host: localhost
 port: 23231
 


### PR DESCRIPTION
I believe this was meant by the `reverse proxy` wording. But I believe this wording is confusing because it means something specific for http proxying