### PR TITLE
Use different branch name as the default

### DIFF
--- a/config/git.go
+++ b/config/git.go
@@ -225,7 +225,7 @@ func (rs *RepoSource) InitRepo(name string, bare bool) (*Repo, error) {
 		path:       rp,
 		repository: rg,
 		refs: []*git.Reference{
-			git.NewReference(rp, git.RefsHeads+"master"),
+			git.NewReference(rp, git.RefsHeads+"main"),
 		},
 	}
 	rs.repos[name] = r


### PR DESCRIPTION
To align with the default from various other forges (GitHub, GitLab, Gitea, etc..), and the git client itself. I've updated the default branch name for new repos to match.