### PR TITLE
feat: serve index.html for go modules

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -55,6 +55,13 @@ type DBConfig struct {
 	SSLMode  bool   `env:"SSL_MODE" envDefault:"false"`
 }
 
+// HTTPConfig is the HTTP server config.
+type HTTPConfig struct {
+	Enabled bool   `env:"ENABLED" envDefault:"true"`
+	Port    int    `env:"PORT" envDefault:"8080"`
+	Domain  string `env:"DOMAIN" envDefault:"localhost"` // used for go get
+}
+
 // URL returns a database URL for the configuration.
 func (d *DBConfig) URL() *url.URL {
 	switch d.Driver {
@@ -88,9 +95,10 @@ func (d *DBConfig) URL() *url.URL {
 type Config struct {
 	Host string `env:"HOST" envDefault:"localhost"`
 
-	SSH SSHConfig `env:"SSH" envPrefix:"SSH_"`
-	Git GitConfig `env:"GIT" envPrefix:"GIT_"`
-	Db  DBConfig  `env:"DB" envPrefix:"DB_"`
+	SSH  SSHConfig  `env:"SSH" envPrefix:"SSH_"`
+	Git  GitConfig  `env:"GIT" envPrefix:"GIT_"`
+	HTTP HTTPConfig `env:"HTTP" envPrefix:"HTTP_"`
+	Db   DBConfig   `env:"DB" envPrefix:"DB_"`
 
 	ServerName string            `env:"SERVER_NAME" envDefault:"Soft Serve"`
 	AnonAccess proto.AccessLevel `env:"ANON_ACCESS" envDefault:"read-only"`
@@ -174,12 +182,12 @@ func DefaultConfig() *Config {
 		cfg.InitialAdminKeys[i] = pk
 	}
 	// init data path and db
-	if err := os.MkdirAll(cfg.RepoPath(), 0755); err != nil {
+	if err := os.MkdirAll(cfg.RepoPath(), 0o755); err != nil {
 		log.Fatalln(err)
 	}
 	switch cfg.Db.Driver {
 	case "sqlite":
-		if err := os.MkdirAll(filepath.Dir(cfg.DBPath()), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(cfg.DBPath()), 0o755); err != nil {
 			log.Fatalln(err)
 		}
 		db, err := sqlite.New(cfg.DBPath())

--- a/server/http.go
+++ b/server/http.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"html/template"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/soft-serve/server/config"
+)
+
+func newHTTPServer(cfg *config.Config) *http.Server {
+	r := http.NewServeMux()
+	r.HandleFunc("/", repoIndexHandler(cfg))
+	return &http.Server{
+		Addr:              net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.HTTP.Port)),
+		Handler:           r,
+		ReadHeaderTimeout: time.Second * 10,
+		ReadTimeout:       time.Second * 10,
+		WriteTimeout:      time.Second * 10,
+		MaxHeaderBytes:    http.DefaultMaxHeaderBytes,
+	}
+}
+
+var repoIndexHTMLTpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+ 	<meta name="go-import" content="{{ .Config.HTTP.Domain }}/{{ .Repo }} git ssh://{{ .Config.Host }}:{{ .Config.SSH.Port }}/{{ .Repo }}">
+</head>
+</html>`))
+
+func repoIndexHandler(cfg *config.Config) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		repo := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")[0]
+		log.Println("serving index for", repo)
+		if err := repoIndexHTMLTpl.Execute(w, struct {
+			Repo   string
+			Config config.Config
+		}{
+			Repo:   repo,
+			Config: *cfg,
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}


### PR DESCRIPTION
With this, soft-serve will be able to serve Go modules as well!

An simple PoC would be:

```sh
SOFT_SERVE_HTTP_DOMAIN=mydomain.com go run ./cmd/soft serve
sudo ./caddy reverse-proxy --from mydomain.com --to localhost:8080
```

and then you can push your repo (with import-path being something like `mydomain.com/name`) and `go get` it with:

```sh
GOPRIVATE=mydomain.com/name go get mydomain.com/name
```

PS: it only works with default ports (80 and 443), and the https port needs to have a valid certificate (hence using caddy autotls stuff in the example above).

Let me know what you think!