### PR TITLE
feat: add alphabetical, commit and config order to ls and tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ anon-access: read-write
 # You can grant read-only access to users without private keys.
 allow-keyless: false
 
+# You can select the order in which repositories are shown:
+# 'alphabetical': alphabetical order
+# 'commit': repositories with latest commits show first
+# 'config': keep the order of config.yaml -> this is the default option
+repos-order: config
+
 # Customize repos in the menu
 repos:
   - name: Home

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	AllowKeyless bool           `yaml:"allow-keyless" json:"allow-keyless"`
 	Users        []User         `yaml:"users" json:"users"`
 	Repos        []RepoConfig   `yaml:"repos" json:"repos"`
+	ReposOrder   string         `yaml:"repos-order" json:"repos-order"`
 	Source       *RepoSource    `yaml:"-" json:"-"`
 	Cfg          *config.Config `yaml:"-" json:"-"`
 	mtx          sync.Mutex
@@ -89,7 +90,10 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		pks = append(pks, pk)
 	}
 
-	rs := NewRepoSource(cfg.RepoPath)
+	rs, err := NewRepoSource(cfg.RepoPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repository source folder: %w\n", err)
+	}
 	c := &Config{
 		Cfg: cfg,
 	}
@@ -123,10 +127,11 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		yamlUsers = fmt.Sprintf(hasKeyUserConfig, result)
 	}
 	yaml := fmt.Sprintf("%s%s%s", yamlConfig, yamlUsers, exampleUserConfig)
-	err := c.createDefaultConfigRepo(yaml)
+	err = c.createDefaultConfigRepo(yaml)
 	if err != nil {
 		return nil, err
 	}
+
 	return c, nil
 }
 
@@ -179,6 +184,7 @@ func (cfg *Config) Reload() error {
 	if err := cfg.readConfig("config", cfg); err != nil {
 		return fmt.Errorf("error reading config: %w", err)
 	}
+	cfg.Source.Sort(cfg.ReposOrder, cfg.Repos)
 	// sanitize repo configs
 	repos := make(map[string]RepoConfig, 0)
 	for _, r := range cfg.Repos {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -19,6 +19,12 @@ anon-access: %s
 # will be accepted.
 allow-keyless: %t
 
+# You can select the order in which repositories are shown:
+# 'alphabetical': alphabetical order
+# 'commit': repositories with latest commits show first
+# 'config': keep the order of config.yaml -> this is the default option
+repos-order: config
+
 # Customize repo display in the menu.
 repos:
   - name: Home

--- a/config/git_test.go
+++ b/config/git_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestNewRepoSource(t *testing.T) {
+	repoPath := "./testdata"
+	rs, err := NewRepoSource(repoPath)
+	repos := []string{
+		"z-repo",
+		"1-repo",
+		"a-repo",
+		"m-repo",
+		"b-repo",
+	}
+	for _, r := range repos {
+		rs.InitRepo(r, true)
+	}
+	is := is.New(t)
+	is.NoErr(err)
+	is.Equal(len(rs.repos), 5) // there should be 5 repos
+}
+
+func TestOrderReposAlphabetically(t *testing.T) {
+	repoPath := "./testdata"
+	rs, err := NewRepoSource(repoPath)
+	repos := []string{
+		"z-repo",
+		"1-repo",
+		"a-repo",
+		"m-repo",
+		"b-repo",
+	}
+	for _, r := range repos {
+		rs.InitRepo(r, true)
+	}
+	rs.Sort("alphabetical", []RepoConfig{})
+	expected := map[string]int{ // repos and their expected index
+		"1-repo": 0,
+		"a-repo": 1,
+		"b-repo": 2,
+		"m-repo": 3,
+		"z-repo": 4,
+	}
+	result := rs.AllRepos() // as returned from ls command
+	is := is.New(t)
+	is.NoErr(err)
+	for i, repo := range result {
+		is.Equal(expected[repo.Repo()], i) // repos should be alphabetically ordered
+	}
+}
+
+func TestOrderReposConfig(t *testing.T) {
+	repoPath := "./testdata"
+	rs, err := NewRepoSource(repoPath)
+	config := []RepoConfig{
+		{
+			Name: "test-repo-a",
+			Repo: "a-repo",
+		},
+		{
+			Name: "test-repo-1",
+			Repo: "1-repo",
+		},
+		{
+			Name: "test-repo-z",
+			Repo: "z-repo",
+		},
+		{
+			Name: "test-repo-b",
+			Repo: "b-repo",
+		},
+		{
+			Name: "test-repo-m",
+			Repo: "m-repo",
+		},
+	}
+	repos := []string{
+		"z-repo",
+		"1-repo",
+		"a-repo",
+		"m-repo",
+		"b-repo",
+	}
+	for _, r := range repos {
+		rs.InitRepo(r, true)
+	}
+	rs.Sort("config", config)
+	expected := map[string]int{ // repos and their expected index
+		"a-repo": 0,
+		"1-repo": 1,
+		"z-repo": 2,
+		"b-repo": 3,
+		"m-repo": 4,
+	}
+	result := rs.AllRepos() // as returned from ls command
+	is := is.New(t)
+	is.NoErr(err)
+	for i, repo := range result {
+		is.Equal(expected[repo.Repo()], i) // repos should be ordered as in config file
+	}
+}

--- a/ui/pages/selection/selection.go
+++ b/ui/pages/selection/selection.go
@@ -187,21 +187,6 @@ func (s *Selection) Init() tea.Cmd {
 	items := make([]selector.IdentifiableItem, 0)
 	cfg := s.cfg
 	pk := s.pk
-	// Put configured repos first
-	for _, r := range cfg.Repos {
-		acc := cfg.AuthRepo(r.Repo, pk)
-		if r.Private && acc < wgit.ReadOnlyAccess {
-			continue
-		}
-		repo, err := cfg.Source.GetRepo(r.Repo)
-		if err != nil {
-			continue
-		}
-		items = append(items, Item{
-			repo: repo,
-			cmd:  git.RepoURL(cfg.Host, cfg.Port, r.Repo),
-		})
-	}
 	for _, r := range cfg.Source.AllRepos() {
 		if r.Repo() == "config" {
 			rm, rp := r.Readme()
@@ -234,7 +219,7 @@ func (s *Selection) Init() tea.Cmd {
 			items = append(items, Item{
 				repo:       r,
 				lastUpdate: lastUpdate,
-				cmd:        git.RepoURL(cfg.Host, cfg.Port, r.Name()),
+				cmd:        git.RepoURL(cfg.Host, cfg.Port, r.Repo()),
 			})
 		}
 	}


### PR DESCRIPTION
This is still WIP.
Related to #193.

The ideas behind these changes are:

- Using `config.yaml` to set the type of order for the repositories: `alphabetical`, `commit` or `config`.
- Adding a new field `sorted` to the `RepoSource` struct.
- Implementing a method `Sort` on` RepoSource`.
- Calling this method `Sort` when the configuration is loaded.
- It applies for both `ls` and TUI.
- The default behavior is to follow the order in `config.yaml`. The remaining repositories that don't appear in the config file are appended at the end with no specific order.
- If using `commit`, the repositories with most recent commits are shown first.
- Some tests were added as well.

After giving it some thought, this is what felt sensible to me. Is it aligned with the original idea?

Thanks in advance for the feedback.