### PR TITLE
fix(go): remove go.mod exclude directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,3 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-// see https://github.com/sergi/go-diff/issues/123
-exclude github.com/sergi/go-diff v1.2.0


### PR DESCRIPTION
`go install` doesn't like `exclude/replace` directives in go.mod

Fixes: https://github.com/charmbracelet/soft-serve/issues/213
Fixes: https://github.com/charmbracelet/soft-serve/issues/201