### PR TITLE
Change `brew` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ manager:
 
 ```bash
 # macOS or Linux
-brew tap charmbracelet/tap && brew install charmbracelet/tap/soft-serve
+brew install charmbracelet/tap/soft-serve
 
 # Arch Linux
 pacman -S soft-serve


### PR DESCRIPTION
You don't need to run `brew tap` if you specify a repository when installing.