### PR TITLE
fix: increase clone timeout, fix some lint issues

### DIFF
--- a/git/repo.go
+++ b/git/repo.go
@@ -41,16 +41,6 @@ func Init(path string, bare bool) (*Repository, error) {
 	return Open(path)
 }
 
-func isInsideWorkTree(r *git.Repository) bool {
-	out, err := r.RevParse("--is-inside-work-tree")
-	return err == nil && out == "true"
-}
-
-func isInsideGitDir(r *git.Repository) bool {
-	out, err := r.RevParse("--is-inside-git-dir")
-	return err == nil && out == "true"
-}
-
 func gitDir(r *git.Repository) (string, error) {
 	return r.RevParse("--git-dir")
 }
@@ -192,7 +182,7 @@ func (r *Repository) Patch(commit *Commit) (string, error) {
 
 // CountCommits returns the number of commits in the repository.
 func (r *Repository) CountCommits(ref *Reference) (int64, error) {
-	return r.Repository.RevListCount([]string{ref.Name().String()})
+	return r.RevListCount([]string{ref.Name().String()})
 }
 
 // CommitsByPage returns the commits for a given page and size.

--- a/server/backend/sqlite/sqlite.go
+++ b/server/backend/sqlite/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/log"
 	"github.com/charmbracelet/soft-serve/git"
@@ -14,12 +15,12 @@ import (
 	"github.com/charmbracelet/soft-serve/server/hooks"
 	"github.com/charmbracelet/soft-serve/server/utils"
 	"github.com/jmoiron/sqlx"
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // sqlite driver
 )
 
 // SqliteBackend is a backend that uses a SQLite database as a Soft Serve
 // backend.
-type SqliteBackend struct {
+type SqliteBackend struct { //nolint: revive
 	cfg    *config.Config
 	ctx    context.Context
 	dp     string
@@ -177,9 +178,10 @@ func (d *SqliteBackend) ImportRepository(name string, remote string, opts backen
 	rp := filepath.Join(d.reposPath(), repo)
 
 	copts := git.CloneOptions{
-		Bare:   true,
-		Mirror: opts.Mirror,
-		Quiet:  true,
+		Bare:    true,
+		Mirror:  opts.Mirror,
+		Quiet:   true,
+		Timeout: 15 * time.Minute,
 		CommandOptions: git.CommandOptions{
 			Envs: []string{
 				fmt.Sprintf(`GIT_SSH_COMMAND=ssh -o UserKnownHostsFile="%s" -o StrictHostKeyChecking=no -i "%s"`,


### PR DESCRIPTION
- increase clone timeout from 1m to 15m
  - otherwise, bigger repos might just fail to import
- removed some unused functions
- cleaned up a couple of lint issues