### PR TITLE
fix: set CI=1 in Dockerfile as a workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ VOLUME /soft-serve
 # Environment variables
 ENV SOFT_SERVE_DATA_PATH "/soft-serve"
 ENV SOFT_SERVE_INITIAL_ADMIN_KEYS ""
+# workaround to prevent slowness in docker when running with a tty
+ENV CI "1"
 
 # Expose ports
 # SSH


### PR DESCRIPTION
if you run soft-serve in a docker container with `--tty` (default in synology nas, and I imagine, probably in other Docker UIs too), every bg/fg query will timeout (after 5s), so, it has a 10s delay to start (because it checks both bg and fg on startup), and then SSH-ing into the TUI is impossible as it keeps doing queries nonstop.

This is a workaround to prevent this issue until we finish working on a proper fix.