### PR TITLE
perf: update mirrors in a workpool

### DIFF
--- a/cmd/soft/root.go
+++ b/cmd/soft/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	. "github.com/charmbracelet/soft-serve/internal/log"
 	"github.com/spf13/cobra"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 var (
@@ -52,6 +53,13 @@ func init() {
 
 func main() {
 	logger := NewDefaultLogger()
+
+	// Set the max number of processes to the number of CPUs
+	// This is useful when running soft serve in a container
+	if _, err := maxprocs.Set(maxprocs.Logger(logger.Debugf)); err != nil {
+		logger.Warn("couldn't set automaxprocs", "error", err)
+	}
+
 	ctx := log.WithContext(context.Background(), logger)
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.15.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.7.0
+	go.uber.org/automaxprocs v1.5.2
 	goji.io v2.0.2+incompatible
 	golang.org/x/crypto v0.9.0
 	golang.org/x/sync v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFz
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_golang v1.15.1 h1:8tXpTmJbyH5lydzFPoxSIJ0J46jdh3tylbvM1xCv0LI=
 github.com/prometheus/client_golang v1.15.1/go.mod h1:e9yaBhRPU2pPNsZwE+JdQl0KEt1N9XgF6zxWmaC0xOk=
 github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
@@ -207,6 +208,8 @@ github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
 github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18Wa1os=
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
+go.uber.org/automaxprocs v1.5.2 h1:2LxUOGiR3O6tw8ui5sZa2LAaHnsviZdVOUZw4fvbnME=
+go.uber.org/automaxprocs v1.5.2/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 goji.io v2.0.2+incompatible h1:uIssv/elbKRLznFUy3Xj4+2Mz/qKhek/9aZQDUMae7c=
 goji.io v2.0.2+incompatible/go.mod h1:sbqFwrtqZACxLBTQcdgVjFh54yGVCvwq8+w49MVMMIk=
 golang.org/x/arch v0.1.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=

--- a/internal/sync/workqueue.go
+++ b/internal/sync/workqueue.go
@@ -1,0 +1,82 @@
+package sync
+
+import "sync"
+
+// WorkQueue is a queue of work to be done.
+type WorkQueue struct {
+	work   map[string]func()
+	wokers int
+	mu     sync.RWMutex
+	queue  chan string
+}
+
+// NewWorkQueue creates a new work queue. The workers argument specifies the
+// number of concurrent workers to run the work.
+// The queue will chunk the work into batches of workers size.
+func NewWorkQueue(workers int) *WorkQueue {
+	if workers <= 0 {
+		workers = 1
+	}
+
+	return &WorkQueue{
+		queue:  make(chan string),
+		work:   make(map[string]func()),
+		wokers: workers,
+	}
+}
+
+// Run starts the workers and waits for them to finish.
+func (wq *WorkQueue) Run() {
+	for {
+		wq.mu.RLock()
+		work := len(wq.work)
+		wq.mu.RUnlock()
+		if work <= 0 {
+			break
+		}
+
+		var wg sync.WaitGroup
+
+		workers := wq.wokers
+		if workers > work {
+			workers = work
+		}
+
+		wg.Add(workers)
+		for id, fn := range wq.work {
+			if workers <= 0 {
+				break
+			}
+
+			go func(id string, fn func()) {
+				defer wg.Done()
+				fn()
+				wq.mu.Lock()
+				delete(wq.work, id)
+				wq.mu.Unlock()
+			}(id, fn)
+
+			workers--
+		}
+
+		wg.Wait()
+	}
+}
+
+// Add adds a new job to the queue.
+func (wq *WorkQueue) Add(id string, fn func()) {
+	wq.mu.Lock()
+	defer wq.mu.Unlock()
+	if _, ok := wq.work[id]; ok {
+		return
+	}
+	wq.work[id] = fn
+}
+
+// Status returns the Status of the given key.
+func (wq *WorkQueue) Status(id string) bool {
+	wq.mu.RLock()
+	defer wq.mu.RUnlock()
+	_, ok := wq.work[id]
+	return ok
+}

--- a/server/jobs.go
+++ b/server/jobs.go
@@ -9,11 +9,9 @@ import (
 	"github.com/charmbracelet/soft-serve/internal/sync"
 )
 
-var (
-	jobSpecs = map[string]string{
-		"mirror": "@every 10m",
-	}
-)
+var jobSpecs = map[string]string{
+	"mirror": "@every 10m",
+}
 
 // mirrorJob runs the (pull) mirror job task.
 func (s *Server) mirrorJob() func() {
@@ -28,7 +26,7 @@ func (s *Server) mirrorJob() func() {
 		}
 
 		// Divide the work up among the number of CPUs.
-		wq := sync.NewWorkQueue(runtime.NumCPU() / 4)
+		wq := sync.NewWorkQueue(runtime.GOMAXPROCS(0))
 
 		for _, repo := range repos {
 			if repo.IsMirror() {

--- a/server/jobs.go
+++ b/server/jobs.go
@@ -26,11 +26,13 @@ func (s *Server) mirrorJob() func() {
 		}
 
 		// Divide the work up among the number of CPUs.
-		wq := sync.NewWorkQueue(runtime.GOMAXPROCS(0))
+		wq := sync.NewWorkPool(s.ctx, runtime.GOMAXPROCS(0),
+			sync.WithWorkPoolLogger(logger.Errorf),
+		)
 
+		logger.Debug("updating mirror repos")
 		for _, repo := range repos {
 			if repo.IsMirror() {
-				logger.Debug("updating mirror", "repo", repo.Name())
 				r, err := repo.Open()
 				if err != nil {
 					logger.Error("error opening repository", "repo", repo.Name(), "err", err)
@@ -50,7 +52,6 @@ func (s *Server) mirrorJob() func() {
 						logger.Error("error running git remote update", "repo", name, "err", err)
 					}
 
-					logger.Debug("mirror updated", "repo", name)
 				})
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/charmbracelet/log"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/charmbracelet/soft-serve/server/backend"
 	"github.com/charmbracelet/soft-serve/server/backend/sqlite"
@@ -61,8 +62,12 @@ func NewServer(ctx context.Context) (*Server, error) {
 		ctx:     ctx,
 	}
 
+	if _, err := maxprocs.Set(); err != nil {
+		srv.logger.Warn("automaxprocs", "error", err)
+	}
+
 	// Add cron jobs.
-	srv.Cron.AddFunc(jobSpecs["mirror"], srv.mirrorJob())
+	_, _ = srv.Cron.AddFunc(jobSpecs["mirror"], srv.mirrorJob())
 
 	srv.SSHServer, err = sshsrv.NewSSHServer(ctx)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/charmbracelet/log"
-	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/charmbracelet/soft-serve/server/backend"
 	"github.com/charmbracelet/soft-serve/server/backend/sqlite"
@@ -60,10 +59,6 @@ func NewServer(ctx context.Context) (*Server, error) {
 		Backend: cfg.Backend,
 		logger:  log.FromContext(ctx).WithPrefix("server"),
 		ctx:     ctx,
-	}
-
-	if _, err := maxprocs.Set(); err != nil {
-		srv.logger.Warn("automaxprocs", "error", err)
 	}
 
 	// Add cron jobs.


### PR DESCRIPTION
Implement a simple chunked workqueue to queue updating mirrors. We use the number of cpus to calculate the number of workers to distribute the work to.