### PR TITLE
feat: bump minimum go version to go1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/charmbracelet/soft-serve
 
-go 1.18
+go 1.20
 
 require (
 	github.com/alecthomas/chroma v0.10.0


### PR DESCRIPTION
Soft Serve already uses symbols introduced in go1.20

Fixes: https://github.com/charmbracelet/soft-serve/issues/293