### PR TITLE
README: add Windows install instruction for Winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ manager:
 # macOS or Linux
 brew tap charmbracelet/tap && brew install charmbracelet/tap/soft-serve
 
+## Windows (with Winget)
+winget install charmbracelet.soft-serve
+
 # Arch Linux
 pacman -S soft-serve
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ manager:
 brew tap charmbracelet/tap && brew install charmbracelet/tap/soft-serve
 
 ## Windows (with Winget)
-winget install charmbracelet.soft-serve
+winget install soft-serve
 
 # Arch Linux
 pacman -S soft-serve

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ manager:
 # macOS or Linux
 brew tap charmbracelet/tap && brew install charmbracelet/tap/soft-serve
 
-## Windows (with Winget)
-winget install soft-serve
+# Windows (with Winget)
+winget install charmbracelet.soft-serve
 
 # Arch Linux
 pacman -S soft-serve


### PR DESCRIPTION
## Changes

- Add Windows Install instruction for Winget.

Recently, I added the [manifest](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/charmbracelet/soft-serve) for `soft-serve` to Winget. Once new releases are made, I will update the Winget manifest asap. I have referred to `glow` README for this template.