### PR TITLE
fix: ignore case README filenames

### DIFF
--- a/server/backend/utils.go
+++ b/server/backend/utils.go
@@ -16,6 +16,7 @@ func LatestFile(r Repository, pattern string) (string, string, error) {
 
 // Readme returns the repository's README.
 func Readme(r Repository) (readme string, path string, err error) {
-	readme, path, err = LatestFile(r, "README*")
+	pattern := "[rR][eE][aA][dD][mM][eE]*"
+	readme, path, err = LatestFile(r, pattern)
 	return
 }


### PR DESCRIPTION
## Changes
- [x] make README.md case-insensitive

![spongebob readme contents](https://github.com/charmbracelet/soft-serve/assets/15822994/71e60b2e-b764-4e38-9117-79f14d2e1c0f)
![spongebob readme](https://github.com/charmbracelet/soft-serve/assets/15822994/54033d8d-fcb6-4d7d-a463-bb6f0c4467c7)

![capitalized readme contents](https://github.com/charmbracelet/soft-serve/assets/15822994/a52e5706-f7d0-4f85-b7ea-46074395769d)
![capitalized readme](https://github.com/charmbracelet/soft-serve/assets/15822994/8815db5e-2540-4e81-a792-c963ced60130)

![lower readme contents](https://github.com/charmbracelet/soft-serve/assets/15822994/228698f9-ee78-4b6e-abdb-3883450e00c1)
![lower readme](https://github.com/charmbracelet/soft-serve/assets/15822994/c2ff7d6f-cc33-4cbc-ae45-15762e84b63d)
