### PR TITLE
Add commit command

### DIFF
--- a/server/cmd/commit.go
+++ b/server/cmd/commit.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	gansi "github.com/charmbracelet/glamour/ansi"
+	"github.com/charmbracelet/soft-serve/git"
+	"github.com/charmbracelet/soft-serve/server/ui/common"
+	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
+)
+
+// commitCommand returns a command that prints the contents of a commit.
+func commitCommand() *cobra.Command {
+	var color bool
+
+	cmd := &cobra.Command{
+		Use:               "commit SHA",
+		Short:             "Print out the contents of a diff",
+		Args:              cobra.ExactArgs(2),
+		PersistentPreRunE: checkIfReadable,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _ := fromContext(cmd)
+			repoName := args[0]
+			commitSHA := args[1]
+
+			rr, err := cfg.Backend.Repository(repoName)
+			if err != nil {
+				return err
+			}
+
+			r, err := rr.Open()
+			if err != nil {
+				return err
+			}
+
+			raw_commit, err := r.CommitByRevision(commitSHA)
+
+			commit := &git.Commit{
+				Commit: raw_commit,
+				Hash:   git.Hash(rn),
+			}
+
+			patch, err := r.Patch(commit)
+			if err != nil {
+				return err
+			}
+
+			var s strings.Builder
+			var pr strings.Builder
+
+			diffChroma := &gansi.CodeBlockElement{
+				Code:     patch,
+				Language: "diff",
+			}
+
+			err = diffChroma.Render(&pr, renderCtx())
+
+			if err != nil {
+				s.WriteString(fmt.Sprintf("\n%s", err.Error()))
+			} else {
+				s.WriteString(fmt.Sprintf("\n%s", pr.String()))
+			}
+
+			cmd.Println(s.String())
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&color, "color", "c", false, "Colorize output")
+
+	return cmd
+}
+
+func renderCtx() gansi.RenderContext {
+	return gansi.NewRenderContext(gansi.Options{
+		ColorProfile: termenv.TrueColor,
+		Styles:       common.StyleConfig(),
+	})
+}

--- a/server/cmd/commit.go
+++ b/server/cmd/commit.go
@@ -89,8 +89,10 @@ func commitCommand() *cobra.Command {
 				))
 			}
 
-			s.WriteString(statsLine)
-			s.WriteString(diffLine)
+			s.WriteString(fmt.Sprintf("\n%s\n%s",
+				statsLine,
+				diffLine,
+			))
 
 			cmd.Println(
 				s.String(),

--- a/server/cmd/commit.go
+++ b/server/cmd/commit.go
@@ -47,23 +47,29 @@ func commitCommand() *cobra.Command {
 				return err
 			}
 
-			var s strings.Builder
-			var pr strings.Builder
+			c := string(patch)
 
-			diffChroma := &gansi.CodeBlockElement{
-				Code:     patch,
-				Language: "diff",
+			if color {
+				var s strings.Builder
+				var pr strings.Builder
+
+				diffChroma := &gansi.CodeBlockElement{
+					Code:     patch,
+					Language: "diff",
+				}
+
+				err = diffChroma.Render(&pr, renderCtx())
+
+				if err != nil {
+					s.WriteString(fmt.Sprintf("\n%s", err.Error()))
+				} else {
+					s.WriteString(fmt.Sprintf("\n%s", pr.String()))
+				}
+
+				c = s.String()
 			}
 
-			err = diffChroma.Render(&pr, renderCtx())
-
-			if err != nil {
-				s.WriteString(fmt.Sprintf("\n%s", err.Error()))
-			} else {
-				s.WriteString(fmt.Sprintf("\n%s", pr.String()))
-			}
-
-			cmd.Println(s.String())
+			cmd.Println(c)
 
 			return nil
 		},

--- a/server/cmd/commit.go
+++ b/server/cmd/commit.go
@@ -39,7 +39,7 @@ func commitCommand() *cobra.Command {
 
 			commit := &git.Commit{
 				Commit: raw_commit,
-				Hash:   git.Hash(rn),
+				Hash:   git.Hash(commitSHA),
 			}
 
 			patch, err := r.Patch(commit)

--- a/server/cmd/repo.go
+++ b/server/cmd/repo.go
@@ -18,6 +18,7 @@ func repoCommand() *cobra.Command {
 		blobCommand(),
 		branchCommand(),
 		collabCommand(),
+		commitCommand(),
 		createCommand(),
 		deleteCommand(),
 		descriptionCommand(),


### PR DESCRIPTION
### Description
This PR adds a `repo commit` command that implements #330.

### QA
- Installed soft locally
- Started an instance
- Pushed a repo
- Ran the command on a repo

Here's the actual text of the command and its output
```shell
soft-serve on  main [!?] via 🐳 desktop-linux via 🐹 v1.20.3 on ☁️  (us-east-1)
✦ ❯ ssh test repo commit soft 191b8320a037dbb30fa36630b785ff4674c16d64 -c
The authenticity of host '[localhost]:23231 ([::1]:23231)' can't be established.
ED25519 key fingerprint is SHA256:ZEXFXEWF/kZa6MVCMvV65jfyc2GyYabkogseZ3WCxGw.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[localhost]:23231' (ED25519) to the list of known hosts.

  diff --git a/go.mod b/go.mod
  index 3bb9f77ba5d9d3ae88ff4dac0a1b1143850d47d2..7abac3f8ff7972a064f0118aed5feba1ccc8bc32 100644
  --- a/go.mod
  +++ b/go.mod
  @@ -19,7 +19,7 @@ require (

   require (
   	github.com/caarlos0/env/v8 v8.0.0
  -	github.com/charmbracelet/keygen v0.4.2
  +	github.com/charmbracelet/keygen v0.4.3
   	github.com/charmbracelet/log v0.2.2
   	github.com/charmbracelet/ssh v0.0.0-20221117183211-483d43d97103
   	github.com/gobwas/glob v0.2.3
  diff --git a/go.sum b/go.sum
  index ae63f72b62d9ff6e9360dd16d4e0bc1de9791e6f..a22804453a8d520351b52a9fdc6d8f3f1c16cce6 100644
  --- a/go.sum
  +++ b/go.sum
  @@ -23,8 +23,8 @@ github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06
   github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
   github.com/charmbracelet/glamour v0.6.0 h1:wi8fse3Y7nfcabbbDuwolqTqMQPMnVPeZhDM273bISc=
   github.com/charmbracelet/glamour v0.6.0/go.mod h1:taqWV4swIMMbWALc0m7AfE9JkPSU8om2538k9ITBxOc=
  -github.com/charmbracelet/keygen v0.4.2 h1:TNHua2MlXc6W1dQB2iW4msSZGKlb8RtxtmYDWUs4iRw=
  -github.com/charmbracelet/keygen v0.4.2/go.mod h1:4e4FT3HSdLU/u83RfJWvzJIaVb8aX4MxtDlfXwpDJaI=
  +github.com/charmbracelet/keygen v0.4.3 h1:ywOZRwkDlpmkawl0BgLTxaYWDSqp6Y4nfVVmgyyO1Mg=
  +github.com/charmbracelet/keygen v0.4.3/go.mod h1:4e4FT3HSdLU/u83RfJWvzJIaVb8aX4MxtDlfXwpDJaI=
   github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
   github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
   github.com/charmbracelet/log v0.2.2 h1:CaXgos+ikGn5tcws5Cw3paQuk9e/8bIwuYGhnkqQFjo=

```

### Screeenshots

With color
![CleanShot 2023-06-29 at 18 24 56@2x](https://github.com/charmbracelet/soft-serve/assets/19473996/9f663009-3eba-4278-bb9e-58e78288301c)

Colorless
<img width="696" alt="CleanShot 2023-06-29 at 18 54 40@2x" src="https://github.com/charmbracelet/soft-serve/assets/19473996/d26cdf3e-7251-42d2-bd20-92895c824343">



