### PR TITLE
feat,fix: add task manager

### DIFF
--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -7,17 +7,19 @@ import (
 	"github.com/charmbracelet/soft-serve/server/config"
 	"github.com/charmbracelet/soft-serve/server/db"
 	"github.com/charmbracelet/soft-serve/server/store"
+	"github.com/charmbracelet/soft-serve/server/task"
 )
 
 // Backend is the Soft Serve backend that handles users, repositories, and
 // server settings management and operations.
 type Backend struct {
-	ctx    context.Context
-	cfg    *config.Config
-	db     *db.DB
-	store  store.Store
-	logger *log.Logger
-	cache  *cache
+	ctx     context.Context
+	cfg     *config.Config
+	db      *db.DB
+	store   store.Store
+	logger  *log.Logger
+	cache   *cache
+	manager *task.Manager
 }
 
 // New returns a new Soft Serve backend.
@@ -25,11 +27,12 @@ func New(ctx context.Context, cfg *config.Config, db *db.DB) *Backend {
 	dbstore := store.FromContext(ctx)
 	logger := log.FromContext(ctx).WithPrefix("backend")
 	b := &Backend{
-		ctx:    ctx,
-		cfg:    cfg,
-		db:     db,
-		store:  dbstore,
-		logger: logger,
+		ctx:     ctx,
+		cfg:     cfg,
+		db:      db,
+		store:   dbstore,
+		logger:  logger,
+		manager: task.NewManager(ctx),
 	}
 
 	// TODO: implement a proper caching interface

--- a/server/ssh/cmd/import.go
+++ b/server/ssh/cmd/import.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/charmbracelet/soft-serve/server/backend"
 	"github.com/charmbracelet/soft-serve/server/proto"
+	"github.com/charmbracelet/soft-serve/server/task"
 	"github.com/spf13/cobra"
 )
 
@@ -36,8 +39,13 @@ func importCommand() *cobra.Command {
 				LFS:         lfs,
 				LFSEndpoint: lfsEndpoint,
 			}); err != nil {
+				if errors.Is(err, task.ErrAlreadyStarted) {
+					return errors.New("import already in progress")
+				}
+
 				return err
 			}
+
 			return nil
 		},
 	}

--- a/server/task/manager.go
+++ b/server/task/manager.go
@@ -1,0 +1,116 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	// ErrNotFound is returned when a process is not found.
+	ErrNotFound = errors.New("task not found")
+
+	// ErrAlreadyStarted is returned when a process is already started.
+	ErrAlreadyStarted = errors.New("task already started")
+)
+
+// Task is a task that can be started and stopped.
+type Task struct {
+	id      string
+	fn      func(context.Context) error
+	started atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	err     error
+}
+
+// Manager manages tasks.
+type Manager struct {
+	m   sync.Map
+	ctx context.Context
+}
+
+// NewManager returns a new task manager.
+func NewManager(ctx context.Context) *Manager {
+	return &Manager{
+		m:   sync.Map{},
+		ctx: ctx,
+	}
+}
+
+// Add adds a task to the manager.
+// If the process already exists, it is a no-op.
+func (m *Manager) Add(id string, fn func(context.Context) error) {
+	if m.Exists(id) {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.m.Store(id, &Task{
+		id:     id,
+		fn:     fn,
+		ctx:    ctx,
+		cancel: cancel,
+	})
+}
+
+// Stop stops the task and removes it from the manager.
+func (m *Manager) Stop(id string) error {
+	v, ok := m.m.Load(id)
+	if !ok {
+		return ErrNotFound
+	}
+
+	p := v.(*Task)
+	p.cancel()
+
+	m.m.Delete(id)
+	return nil
+}
+
+// Exists checks if a task exists.
+func (m *Manager) Exists(id string) bool {
+	_, ok := m.m.Load(id)
+	return ok
+}
+
+// Run starts the task if it exists.
+// Otherwise, it waits for the process to finish.
+func (m *Manager) Run(id string, done chan<- error) {
+	v, ok := m.m.Load(id)
+	if !ok {
+		done <- ErrNotFound
+		return
+	}
+
+	p := v.(*Task)
+	if p.started.Load() {
+		<-p.ctx.Done()
+		if p.err != nil {
+			done <- p.err
+			return
+		}
+
+		done <- p.ctx.Err()
+	}
+
+	p.started.Store(true)
+	m.m.Store(id, p)
+	defer p.cancel()
+	defer m.m.Delete(id)
+
+	errc := make(chan error, 1)
+	go func(ctx context.Context) {
+		errc <- p.fn(ctx)
+	}(p.ctx)
+
+	select {
+	case <-m.ctx.Done():
+		done <- m.ctx.Err()
+	case err := <-errc:
+		p.err = err
+		m.m.Store(id, p)
+		done <- err
+	}
+}


### PR DESCRIPTION
Implement a task manager that can run different tasks given a unique ID.

This is needed to accommodate expensive tasks like importing a large repository. The current behavior uses the connection's context (the SSH connection) to import the repository. However, if the server has defined an SSH `idle_timeout`, `max_timeout`, and/or the connection drops, Soft Serve cancels the git clone process and aborts importing the repository.

Instead, we add the import task to the "task manager" and wait on the connection context. If a task already exists for the same repository, return `Error: import already in progress`.

Fixes: https://github.com/charmbracelet/soft-serve/issues/348