### PR TITLE
feat: print clone url on repo create

### DIFF
--- a/testscript/script_test.go
+++ b/testscript/script_test.go
@@ -99,8 +99,7 @@ func TestScript(t *testing.T) {
 			cfg.Stats.ListenAddr = statsListen
 			cfg.DB.Driver = "sqlite"
 			cfg.LFS.Enabled = true
-			// TODO: run tests with both SSH enabled/disabled
-			cfg.LFS.SSHEnabled = false
+			cfg.LFS.SSHEnabled = true
 
 			if err := cfg.Validate(); err != nil {
 				return err

--- a/testscript/testdata/repo-create.txtar
+++ b/testscript/testdata/repo-create.txtar
@@ -5,6 +5,8 @@
 
 # create a repo
 soft repo create repo1 -d 'description' -H -p -n 'repo11'
+stderr 'Created repository repo1.*'
+stdout ssh://localhost:$SSH_PORT/repo1.git
 soft repo hidden repo1
 stdout true
 soft repo private repo1
@@ -95,6 +97,8 @@ soft user create bar --key "$USER1_AUTHORIZED_KEY"
 
 # user create a repo
 usoft repo create repo2 -d 'description' -H -p -n 'repo2'
+stderr 'Created repository repo2.*'
+stdout ssh://localhost:$SSH_PORT/repo2.git
 usoft repo hidden repo2
 stdout true
 usoft repo private repo2


### PR DESCRIPTION
Prints the repo ssh clone url on create

Fixes: https://github.com/charmbracelet/soft-serve/issues/297