### PR TITLE
refactor,fix: add rename lfs objects migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ lfs:
   # Enable Git LFS.
   enabled: true
   # Enable Git SSH transfer.
-  ssh_enabled: true
+  ssh_enabled: false
 
 # Cron job configuration
 jobs:
@@ -267,6 +267,8 @@ You can specify a database connection password in the _data source_ url. For exa
 Soft Serve supports both Git LFS [HTTP](https://github.com/git-lfs/git-lfs/blob/main/docs/api/README.md) and [SSH](https://github.com/git-lfs/git-lfs/blob/main/docs/proposals/ssh_adapter.md) protocols out of the box, there is no need to do any extra set up.
 
 Use the `lfs` config section to customize your Git LFS server.
+
+> **Note**: The pure-SSH transfer is disabled by default.
 
 ## Server Access
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/caarlos0/duration v0.0.0-20220103233809-8df7c22fe305
 	github.com/caarlos0/env/v8 v8.0.0
 	github.com/caarlos0/tablewriter v0.1.0
-	github.com/charmbracelet/git-lfs-transfer v0.1.1-0.20230725143853-5dd0632f9245
+	github.com/charmbracelet/git-lfs-transfer v0.1.1-0.20231027181609-f7ff6baf2ed0
 	github.com/charmbracelet/keygen v0.5.0
 	github.com/charmbracelet/log v0.2.5
 	github.com/charmbracelet/ssh v0.0.0-20230822194956-1a051f898e09

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/charmbracelet/bubbles v0.16.1 h1:6uzpAAaT9ZqKssntbvZMlksWHruQLNxg49H5
 github.com/charmbracelet/bubbles v0.16.1/go.mod h1:2QCp9LFlEsBQMvIYERr7Ww2H2bA7xen1idUDIzm/+Xc=
 github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06RaW2cx/SY=
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
-github.com/charmbracelet/git-lfs-transfer v0.1.1-0.20230725143853-5dd0632f9245 h1:PeGKqKX84IAFhFSWjTyPGiLzzEPcv94C9qKsYBk2nbQ=
-github.com/charmbracelet/git-lfs-transfer v0.1.1-0.20230725143853-5dd0632f9245/go.mod h1:eXJuVicxnjRgRMokmutZdistxoMRjBjjfqvrYq7bCIU=
+github.com/charmbracelet/git-lfs-transfer v0.1.1-0.20231027181609-f7ff6baf2ed0 h1:Wi80d2xNAqvi6r8Udlc9UgPMdrJ+ld5ylKH7d8SQ7gE=
+github.com/charmbracelet/git-lfs-transfer v0.1.1-0.20231027181609-f7ff6baf2ed0/go.mod h1:AHLgIZ2TXQCgt3pDNXR6FgmpGHLH1wPM9cEJPHSVaYg=
 github.com/charmbracelet/glamour v0.6.0 h1:wi8fse3Y7nfcabbbDuwolqTqMQPMnVPeZhDM273bISc=
 github.com/charmbracelet/glamour v0.6.0/go.mod h1:taqWV4swIMMbWALc0m7AfE9JkPSU8om2538k9ITBxOc=
 github.com/charmbracelet/keygen v0.5.0 h1:XY0fsoYiCSM9axkrU+2ziE6u6YjJulo/b9Dghnw6MZc=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -339,7 +339,7 @@ func DefaultConfig() *Config {
 		},
 		LFS: LFSConfig{
 			Enabled:    true,
-			SSHEnabled: true,
+			SSHEnabled: false,
 		},
 	}
 }

--- a/pkg/db/migrate/0003_migrate_lfs_objects.go
+++ b/pkg/db/migrate/0003_migrate_lfs_objects.go
@@ -1,0 +1,70 @@
+package migrate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/charmbracelet/log"
+	"github.com/charmbracelet/soft-serve/pkg/config"
+	"github.com/charmbracelet/soft-serve/pkg/db"
+	"github.com/charmbracelet/soft-serve/pkg/db/models"
+)
+
+const (
+	migrateLfsObjectsName    = "migrate_lfs_objects"
+	migrateLfsObjectsVersion = 3
+)
+
+// Correct LFS objects relative path.
+// From OID[:2]/OID[2:4]/OID[4:] to OID[:2]/OID[2:4]/OID
+// See: https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md#intercepting-git
+var migrateLfsObjects = Migration{
+	Name:    migrateLfsObjectsName,
+	Version: migrateLfsObjectsVersion,
+	Migrate: func(ctx context.Context, tx *db.Tx) error {
+		cfg := config.FromContext(ctx)
+		logger := log.FromContext(ctx).WithPrefix("migrate_lfs_objects")
+
+		var repoIds []int64
+		if err := tx.Select(&repoIds, "SELECT id FROM repos"); err != nil {
+			return err
+		}
+		for _, r := range repoIds {
+			var objs []models.LFSObject
+			if err := tx.Select(&objs, "SELECT * FROM lfs_objects WHERE repo_id = ?", r); err != nil {
+				return err
+			}
+			objsp := filepath.Join(cfg.DataPath, "lfs", strconv.FormatInt(r, 10), "objects")
+			for _, obj := range objs {
+				oldpath := filepath.Join(objsp, badRelativePath(obj.Oid))
+				newpath := filepath.Join(objsp, goodRelativePath(obj.Oid))
+				if _, err := os.Stat(oldpath); err == nil {
+					if err := os.Rename(oldpath, newpath); err != nil {
+						logger.Error("rename lfs object", "oldpath", oldpath, "newpath", newpath, "err", err)
+						continue
+					}
+				}
+			}
+		}
+		return nil
+	},
+	Rollback: func(ctx context.Context, tx *db.Tx) error {
+		return nil
+	},
+}
+
+func goodRelativePath(oid string) string {
+	if len(oid) < 5 {
+		return oid
+	}
+	return filepath.Join(oid[:2], oid[2:4], oid)
+}
+
+func badRelativePath(oid string) string {
+	if len(oid) < 5 {
+		return oid
+	}
+	return filepath.Join(oid[:2], oid[2:4], oid[4:])
+}

--- a/pkg/db/migrate/migrations.go
+++ b/pkg/db/migrate/migrations.go
@@ -17,6 +17,7 @@ var sqls embed.FS
 var migrations = []Migration{
 	createTables,
 	webhooks,
+	migrateLfsObjects,
 }
 
 func execMigration(ctx context.Context, tx *db.Tx, version int, name string, down bool) error {

--- a/pkg/git/lfs_log.go
+++ b/pkg/git/lfs_log.go
@@ -1,0 +1,17 @@
+package git
+
+import (
+	"github.com/charmbracelet/git-lfs-transfer/transfer"
+	"github.com/charmbracelet/log"
+)
+
+type lfsLogger struct {
+	l *log.Logger
+}
+
+var _ transfer.Logger = &lfsLogger{}
+
+// Log implements transfer.Logger.
+func (l *lfsLogger) Log(msg string, kv ...interface{}) {
+	l.l.Debug(msg, kv...)
+}

--- a/pkg/lfs/pointer.go
+++ b/pkg/lfs/pointer.go
@@ -102,12 +102,13 @@ func (p Pointer) String() string {
 }
 
 // RelativePath returns the relative storage path of the pointer
+// https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md#intercepting-git
 func (p Pointer) RelativePath() string {
 	if len(p.Oid) < 5 {
 		return p.Oid
 	}
 
-	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid[4:])
+	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid)
 }
 
 // GeneratePointer generates a pointer for arbitrary content

--- a/pkg/lfs/pointer_test.go
+++ b/pkg/lfs/pointer_test.go
@@ -2,8 +2,8 @@ package lfs
 
 import (
 	"errors"
+	"path"
 	"strconv"
-	"strings"
 	"testing"
 )
 
@@ -78,8 +78,8 @@ size abc
 					t.Errorf("Expected a valid pointer")
 					return
 				}
-				if p.Oid != strings.ReplaceAll(p.RelativePath(), "/", "") {
-					t.Errorf("Expected oid to be the relative path without slashes")
+				if path.Join(p.Oid[:2], p.Oid[2:4], p.Oid) != p.RelativePath() {
+					t.Errorf("Expected a valid relative path")
 					return
 				}
 			}


### PR DESCRIPTION
Rename lfs objects from `OID[:2]/OID[2:4]/OID[4:]` to `OID[:2]/OID[2:4]/OID` to follow specs https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md#intercepting-git