### PR TITLE
fix: use env to generate config.Environ()

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,46 +147,13 @@ type Config struct {
 
 	// DataPath is the path to the directory where Soft Serve will store its data.
 	DataPath string `env:"DATA_PATH" yaml:"-"`
+
+	env []string
 }
 
 // Environ returns the config as a list of environment variables.
 func (c *Config) Environ() []string {
-	envs := []string{}
-	if c == nil {
-		return envs
-	}
-
-	// TODO: do this dynamically
-	envs = append(envs, []string{
-		fmt.Sprintf("SOFT_SERVE_DATA_PATH=%s", c.DataPath),
-		fmt.Sprintf("SOFT_SERVE_NAME=%s", c.Name),
-		fmt.Sprintf("SOFT_SERVE_INITIAL_ADMIN_KEYS=%s", strings.Join(c.InitialAdminKeys, "\n")),
-		fmt.Sprintf("SOFT_SERVE_SSH_LISTEN_ADDR=%s", c.SSH.ListenAddr),
-		fmt.Sprintf("SOFT_SERVE_SSH_PUBLIC_URL=%s", c.SSH.PublicURL),
-		fmt.Sprintf("SOFT_SERVE_SSH_KEY_PATH=%s", c.SSH.KeyPath),
-		fmt.Sprintf("SOFT_SERVE_SSH_CLIENT_KEY_PATH=%s", c.SSH.ClientKeyPath),
-		fmt.Sprintf("SOFT_SERVE_SSH_MAX_TIMEOUT=%d", c.SSH.MaxTimeout),
-		fmt.Sprintf("SOFT_SERVE_SSH_IDLE_TIMEOUT=%d", c.SSH.IdleTimeout),
-		fmt.Sprintf("SOFT_SERVE_GIT_LISTEN_ADDR=%s", c.Git.ListenAddr),
-		fmt.Sprintf("SOFT_SERVE_GIT_PUBLIC_URL=%s", c.Git.PublicURL),
-		fmt.Sprintf("SOFT_SERVE_GIT_MAX_TIMEOUT=%d", c.Git.MaxTimeout),
-		fmt.Sprintf("SOFT_SERVE_GIT_IDLE_TIMEOUT=%d", c.Git.IdleTimeout),
-		fmt.Sprintf("SOFT_SERVE_GIT_MAX_CONNECTIONS=%d", c.Git.MaxConnections),
-		fmt.Sprintf("SOFT_SERVE_HTTP_LISTEN_ADDR=%s", c.HTTP.ListenAddr),
-		fmt.Sprintf("SOFT_SERVE_HTTP_TLS_KEY_PATH=%s", c.HTTP.TLSKeyPath),
-		fmt.Sprintf("SOFT_SERVE_HTTP_TLS_CERT_PATH=%s", c.HTTP.TLSCertPath),
-		fmt.Sprintf("SOFT_SERVE_HTTP_PUBLIC_URL=%s", c.HTTP.PublicURL),
-		fmt.Sprintf("SOFT_SERVE_STATS_LISTEN_ADDR=%s", c.Stats.ListenAddr),
-		fmt.Sprintf("SOFT_SERVE_LOG_FORMAT=%s", c.Log.Format),
-		fmt.Sprintf("SOFT_SERVE_LOG_TIME_FORMAT=%s", c.Log.TimeFormat),
-		fmt.Sprintf("SOFT_SERVE_DB_DRIVER=%s", c.DB.Driver),
-		fmt.Sprintf("SOFT_SERVE_DB_DATA_SOURCE=%s", c.DB.DataSource),
-		fmt.Sprintf("SOFT_SERVE_LFS_ENABLED=%t", c.LFS.Enabled),
-		fmt.Sprintf("SOFT_SERVE_LFS_SSH_ENABLED=%t", c.LFS.SSHEnabled),
-		fmt.Sprintf("SOFT_SERVE_JOBS_MIRROR_PULL=%s", c.Jobs.MirrorPull),
-	}...)
-
-	return envs
+	return c.env
 }
 
 // IsDebug returns true if the server is running in debug mode.
@@ -232,6 +199,13 @@ func parseEnv(cfg *Config) error {
 	// Override with environment variables
 	if err := env.ParseWithOptions(cfg, env.Options{
 		Prefix: "SOFT_SERVE_",
+		OnSet: func(tag string, value interface{}, _ bool) {
+			val := fmt.Sprintf("%v", value)
+			if val == "" {
+				return
+			}
+			cfg.env = append(cfg.env, fmt.Sprintf("%s=%v", tag, value))
+		},
 	}); err != nil {
 		return fmt.Errorf("parse environment variables: %w", err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,24 +10,23 @@ import (
 func TestParseMultipleKeys(t *testing.T) {
 	is := is.New(t)
 	td := t.TempDir()
-	is.NoErr(os.Setenv("SOFT_SERVE_INITIAL_ADMIN_KEYS", "testdata/k1.pub\nssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxIobhwtfdwN7m1TFt9wx3PsfvcAkISGPxmbmbauST8 a@b"))
-	is.NoErr(os.Setenv("SOFT_SERVE_DATA_PATH", td))
-	t.Cleanup(func() {
-		is.NoErr(os.Unsetenv("SOFT_SERVE_INITIAL_ADMIN_KEYS"))
-		is.NoErr(os.Unsetenv("SOFT_SERVE_DATA_PATH"))
-	})
+	t.Setenv("SOFT_SERVE_INITIAL_ADMIN_KEYS", "testdata/k1.pub\nssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxIobhwtfdwN7m1TFt9wx3PsfvcAkISGPxmbmbauST8 a@b")
+	t.Setenv("SOFT_SERVE_DATA_PATH", td)
 	cfg := DefaultConfig()
 	is.NoErr(cfg.ParseEnv())
 	is.Equal(cfg.InitialAdminKeys, []string{
 		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINMwLvyV3ouVrTysUYGoJdl5Vgn5BACKov+n9PlzfPwH",
 		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxIobhwtfdwN7m1TFt9wx3PsfvcAkISGPxmbmbauST8",
 	})
+	is.Equal(cfg.Environ(), []string{
+		"SOFT_SERVE_INITIAL_ADMIN_KEYS=testdata/k1.pub\nssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxIobhwtfdwN7m1TFt9wx3PsfvcAkISGPxmbmbauST8 a@b",
+		"SOFT_SERVE_DATA_PATH=" + td,
+	})
 }
 
 func TestMergeInitAdminKeys(t *testing.T) {
 	is := is.New(t)
-	is.NoErr(os.Setenv("SOFT_SERVE_INITIAL_ADMIN_KEYS", "testdata/k1.pub"))
-	t.Cleanup(func() { is.NoErr(os.Unsetenv("SOFT_SERVE_INITIAL_ADMIN_KEYS")) })
+	t.Setenv("SOFT_SERVE_INITIAL_ADMIN_KEYS", "testdata/k1.pub")
 	cfg := &Config{
 		DataPath:         t.TempDir(),
 		InitialAdminKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxIobhwtfdwN7m1TFt9wx3PsfvcAkISGPxmbmbauST8 a@b"},

--- a/pkg/ssh/session_test.go
+++ b/pkg/ssh/session_test.go
@@ -50,17 +50,10 @@ func TestSession(t *testing.T) {
 
 func setup(tb testing.TB) (*gossh.Session, func() error) {
 	tb.Helper()
-	is := is.New(tb)
 	dp := tb.TempDir()
-	is.NoErr(os.Setenv("SOFT_SERVE_DATA_PATH", dp))
-	is.NoErr(os.Setenv("SOFT_SERVE_GIT_LISTEN_ADDR", ":9418"))
-	is.NoErr(os.Setenv("SOFT_SERVE_SSH_LISTEN_ADDR", fmt.Sprintf(":%d", test.RandomPort())))
-	tb.Cleanup(func() {
-		is.NoErr(os.Unsetenv("SOFT_SERVE_DATA_PATH"))
-		is.NoErr(os.Unsetenv("SOFT_SERVE_GIT_LISTEN_ADDR"))
-		is.NoErr(os.Unsetenv("SOFT_SERVE_SSH_LISTEN_ADDR"))
-		is.NoErr(os.RemoveAll(dp))
-	})
+	tb.Setenv("SOFT_SERVE_DATA_PATH", dp)
+	tb.Setenv("SOFT_SERVE_GIT_LISTEN_ADDR", ":9418")
+	tb.Setenv("SOFT_SERVE_SSH_LISTEN_ADDR", fmt.Sprintf(":%d", test.RandomPort()))
 	ctx := context.TODO()
 	cfg := config.DefaultConfig()
 	if err := cfg.Validate(); err != nil {


### PR DESCRIPTION
this will use the `env`'s `OnSet` to record the variable names and values in order to generate `config.Environ()` results.

The side effect I can think of: if the config values are changed outside of the env after loading, they'll not be applied.

I see we have yaml tags too... if we load the settings from yaml, and then from env (which seems to be the case), it should be fine.