### PR TITLE
build: avoid duplicated CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,10 @@
 name: coverage
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
 
 jobs:
   coverage:

--- a/.github/workflows/lint-soft.yml
+++ b/.github/workflows/lint-soft.yml
@@ -1,6 +1,9 @@
 name: lint-soft
+
 on:
   push:
+    branches:
+      - "main"
   pull_request:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: lint
+
 on:
   push:
+    branches:
+      - "main"
   pull_request:
 
 permissions:


### PR DESCRIPTION
running on both push and pull_request end up running the same job twice for a push on a PR, which waste our CI minutes.