### PR TITLE
Corrected the make repo private example command within the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ To make a repository private, use `repo private <repo> [true|false]`. Private
 repos can only be accessed by admins and collaborators.
 
 ```sh
-ssh -p 23231 localhost repo icecream private true
+ssh -p 23231 localhost repo private icecream true
 ```
 
 ### Repository Branches & Tags


### PR DESCRIPTION
Made a small adjustment to the make repo private command in README.md as the provided example had elements slightly out of order.