### PR TITLE
fix(mirror): skip LFS instead of failing to mirror a repo

### DIFF
--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -190,7 +190,8 @@ func (d *Backend) ImportRepository(_ context.Context, name string, user proto.Us
 
 		client := lfs.NewClient(ep)
 		if client == nil {
-			return fmt.Errorf("failed to create lfs client: unsupported endpoint %s", endpoint)
+			d.logger.Warn("failed to create lfs client: unsupported endpoint", "endpoint", endpoint)
+			return nil
 		}
 
 		if err := StoreRepoMissingLFSObjects(ctx, r, d.db, d.store, client); err != nil {


### PR DESCRIPTION
If an LFS client can't be created because it's not compatible for some reason, skip it entirely for a mirrored repo. This prevents one possible crash when mirroring fails. It still seems to crash when accessing user info, so something is still missing. Either way, it seems valid to skip LFS if it just won't work.

Specifically noticed this when trying to import and mirror a repository using a `git@github.com:user/repo` clone URL, which results in the LFS client being nil. It seemed helpful to keep the error as a warning, but otherwise allow mirroring to continue. There might be a better way to handle this, this just lines up more with how the job.mirror code seems to work at the moment.