### PR TITLE
fix(mirror): add user missing from context

### DIFF
--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -116,6 +116,8 @@ func (d *Backend) ImportRepository(_ context.Context, name string, user proto.Us
 	repoc := make(chan proto.Repository, 1)
 	d.logger.Info("importing repository", "name", name, "remote", remote, "path", rp)
 	d.manager.Add(tid, func(ctx context.Context) (err error) {
+		ctx = proto.WithUserContext(ctx, user)
+
 		copts := git.CloneOptions{
 			Bare:   true,
 			Mirror: opts.Mirror,


### PR DESCRIPTION
DeleteRepository, called when mirroring fails, requires access to the user. The user isn't included in the context for the task, so attach the closed over user to the task context.

Noticed this when importing a repo (from #525) and the mirror failed, causing it to try to delete the repo and eventually crash with a segfault accessing user info. The task seems to run with a new context, so hopefully only needed the user attached to the context. In any case, this prevents a segfault now when the changes from #525 aren't also merged.