### PR TITLE
docs: Simplify installation with brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ manager:
 
 ```bash
 # macOS or Linux
-brew tap charmbracelet/tap && brew install charmbracelet/tap/soft-serve
+brew install charmbracelet/tap/soft-serve
 
 # Windows (with Winget)
 winget install charmbracelet.soft-serve


### PR DESCRIPTION
You don't actually need to tap a brew directory before installation. Tapping would happen automatically before installation.