### PR TITLE
docs(docker README): Update docker file with SOFT_SERVE_INITIAL_ADMIN_KEYS variable

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -18,6 +18,7 @@ docker run \
   --publish 23232:23232 \
   --publish 23233:23233 \
   --publish 9418:9418 \
+  -e SOFT_SERVE_INITIAL_ADMIN_KEYS="YOUR_ADMIN_KEY_HERE" \
   --restart unless-stopped \
   charmcli/soft-serve:latest
 ```
@@ -38,6 +39,8 @@ services:
       - 23232:23232
       - 23233:23233
       - 9418:9418
+    environment:
+      SOFT_SERVE_INITIAL_ADMIN_KEYS: "YOUR_ADMIN_KEY_HERE"
     restart: unless-stopped
 ```
 


### PR DESCRIPTION
Hi there :) I've just been playing around with Soft Serve as I've needed to create a new locally hosted instance, and noticed that the Docker documentation was missing the 'SOFT_SERVE_INITIAL_ADMIN_KEYS' environment variable. I've added this to both the Docker and Docker Compose examples in the docker.md.

If this change is not required for any reason, I'm more than happy to adjust or remove the PR. I do however hope this in a small way helps.