### PR TITLE
sec: do not append session envs to git run

### DIFF
--- a/pkg/ssh/cmd/git.go
+++ b/pkg/ssh/cmd/git.go
@@ -202,9 +202,6 @@ func gitRunE(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	// Add ssh session & config environ
-	s := sshutils.SessionFromContext(ctx)
-	envs = append(envs, s.Environ()...)
 	envs = append(envs, cfg.Environ()...)
 
 	repoPath := filepath.Join(reposDir, repoDir)


### PR DESCRIPTION
It is possible for a user who can commit files to a repository hosted by Soft Serve to execute arbitrary code via environment manipulation and Git LFS.

The issue is that Soft Serve passes all environment variables given by the client to git subprocesses. This includes environment variables that control program execution, such as “LD_PRELOAD”.


This PR fixes it.


---

Reported by Rob King via e-mail