### PR TITLE
build: force use of previous go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1
+          go-version-file: ./go.mod
           cache: true
       - name: Download Go modules
         run: go mod download

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/charmbracelet/soft-serve
 
 go 1.21
 
-toolchain go1.22.0
+toolchain go1.21.0
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0


### PR DESCRIPTION
seems like we haven't had a successful build after the go upgrade to 1.22 

trying to confirm it