### PR TITLE
fix: update position constant in `JoinHorizontal`

### DIFF
--- a/cmd/soft/browse/browse.go
+++ b/cmd/soft/browse/browse.go
@@ -230,7 +230,7 @@ func (m *model) View() string {
 	}
 
 	if m.showFooter {
-		view = lipgloss.JoinVertical(lipgloss.Top, view, m.footer.View())
+		view = lipgloss.JoinVertical(lipgloss.Left, view, m.footer.View())
 	}
 
 	return m.common.Zone.Scan(style.Render(view))

--- a/pkg/ssh/ui.go
+++ b/pkg/ssh/ui.go
@@ -285,10 +285,10 @@ func (ui *UI) View() string {
 		view = "Unknown state :/ this is a bug!"
 	}
 	if ui.activePage == selectionPage {
-		view = lipgloss.JoinVertical(lipgloss.Top, ui.header.View(), view)
+		view = lipgloss.JoinVertical(lipgloss.Left, ui.header.View(), view)
 	}
 	if ui.showFooter {
-		view = lipgloss.JoinVertical(lipgloss.Top, view, ui.footer.View())
+		view = lipgloss.JoinVertical(lipgloss.Left, view, ui.footer.View())
 	}
 	return ui.common.Zone.Scan(
 		ui.common.Styles.App.Render(view),

--- a/pkg/ui/components/code/code.go
+++ b/pkg/ui/components/code/code.go
@@ -114,7 +114,7 @@ func (r *Code) Init() tea.Cmd {
 		for i, l := range lines {
 			lines[i] = common.TruncateString(l, sideNoteWidth)
 		}
-		content = lipgloss.JoinHorizontal(lipgloss.Left, strings.Join(lines, "\n"), content)
+		content = lipgloss.JoinHorizontal(lipgloss.Top, strings.Join(lines, "\n"), content)
 	}
 
 	// Fix styles after hard wrapping

--- a/pkg/ui/pages/repo/log.go
+++ b/pkg/ui/pages/repo/log.go
@@ -276,7 +276,7 @@ func (l *Log) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LogDiffMsg:
 		l.currentDiff = msg
 		l.vp.SetContent(
-			lipgloss.JoinVertical(lipgloss.Top,
+			lipgloss.JoinVertical(lipgloss.Left,
 				l.renderCommit(l.selectedCommit),
 				renderSummary(msg, l.common.Styles, l.common.Width),
 				renderDiff(msg, l.common.Width),
@@ -290,7 +290,7 @@ func (l *Log) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		l.SetSize(msg.Width, msg.Height)
 		if l.selectedCommit != nil && l.currentDiff != nil {
 			l.vp.SetContent(
-				lipgloss.JoinVertical(lipgloss.Top,
+				lipgloss.JoinVertical(lipgloss.Left,
 					l.renderCommit(l.selectedCommit),
 					renderSummary(l.currentDiff, l.common.Styles, l.common.Width),
 					renderDiff(l.currentDiff, l.common.Width),

--- a/pkg/ui/pages/repo/logitem.go
+++ b/pkg/ui/pages/repo/logitem.go
@@ -134,7 +134,7 @@ func (d LogItemDelegate) Render(w io.Writer, m list.Model, index int, listItem l
 		d.common.Zone.Mark(
 			i.ID(),
 			styles.Base.Render(
-				lipgloss.JoinVertical(lipgloss.Top,
+				lipgloss.JoinVertical(lipgloss.Left,
 					truncate.String(fmt.Sprintf("%s%s",
 						title,
 						hash,

--- a/pkg/ui/pages/repo/refsitem.go
+++ b/pkg/ui/pages/repo/refsitem.go
@@ -195,7 +195,7 @@ func (d RefItemDelegate) Render(w io.Writer, m list.Model, index int, listItem l
 		d.common.Zone.Mark(
 			i.ID(),
 			st.Base.Render(
-				lipgloss.JoinHorizontal(lipgloss.Left,
+				lipgloss.JoinHorizontal(lipgloss.Top,
 					truncate.String(selector+ref+desc+hash,
 						uint(m.Width()-horizontalFrameSize)),
 				),

--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -352,7 +352,7 @@ func (r *Repo) headerView() string {
 		urlStyle.Render(url),
 	)
 
-	header = lipgloss.JoinHorizontal(lipgloss.Left, header, url)
+	header = lipgloss.JoinHorizontal(lipgloss.Top, header, url)
 
 	style := r.common.Styles.Repo.Header.Width(r.common.Width)
 	return style.Render(

--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -313,7 +313,7 @@ func (r *Repo) View() string {
 		"repo-main",
 		mainStyle.Render(main),
 	)
-	view := lipgloss.JoinVertical(lipgloss.Top,
+	view := lipgloss.JoinVertical(lipgloss.Left,
 		r.headerView(),
 		r.tabs.View(),
 		main,
@@ -334,7 +334,7 @@ func (r *Repo) headerView() string {
 	header = r.common.Styles.Repo.HeaderName.Render(header)
 	desc := strings.TrimSpace(r.selectedRepo.Description())
 	if desc != "" {
-		header = lipgloss.JoinVertical(lipgloss.Top,
+		header = lipgloss.JoinVertical(lipgloss.Left,
 			header,
 			r.common.Styles.Repo.HeaderDesc.Render(desc),
 		)

--- a/pkg/ui/pages/repo/stash.go
+++ b/pkg/ui/pages/repo/stash.go
@@ -197,7 +197,7 @@ func (s *Stash) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.currentPatch = msg
 		if msg.Diff != nil {
 			title := s.common.Styles.Stash.Title.Render(s.list.SelectedItem().(StashItem).Title())
-			content := lipgloss.JoinVertical(lipgloss.Top,
+			content := lipgloss.JoinVertical(lipgloss.Left,
 				title,
 				"",
 				renderSummary(msg.Diff, s.common.Styles, s.common.Width),


### PR DESCRIPTION
This PR fixes: https://github.com/charmbracelet/soft-serve/issues/540

Ideally, `JoinHorizontal` should expect Top, Bottom, or Center positions. This PR fixes the cases where the Left position constant was used instead of Top.

I found the same thing while looking for `JoinVertical` calls. So I have updated position constants in `JoinVertical` calls as well.