### PR TITLE
Add missing arg length check to fix runtime panic

### DIFF
--- a/pkg/ssh/cmd/branch.go
+++ b/pkg/ssh/cmd/branch.go
@@ -148,6 +148,7 @@ func branchDeleteCommand() *cobra.Command {
 		Use:               "delete REPOSITORY BRANCH",
 		Aliases:           []string{"remove", "rm", "del"},
 		Short:             "Delete a branch",
+		Args:              cobra.ExactArgs(2),
 		PersistentPreRunE: checkIfCollab,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/testscript/testdata/repo-delete.txtar
+++ b/testscript/testdata/repo-delete.txtar
@@ -10,6 +10,11 @@ soft repo create repo-to-delete
 soft repo delete repo-to-delete
 ! soft repo delete nope
 stderr '.*not found.*'
+
+# missing argument should fail
+! soft repo branch delete repo1
+stderr 'Error.*accepts 2 arg.*'
+
 soft repo list
 stdout 'repo1'
 


### PR DESCRIPTION
This one-line fix addresses a missing constraint error; the `ssh <server> repo branch delete` command can induce a runtime panic when accessing `args[1]` if the the branch was not actually specified as an argument.

Repro steps (note: no branch argument specified)
`ssh soft repo branch delete repofoo`

Output (console on server):
```
2024-07-27 16:23:18 ssh: panic: runtime error: index out of range [0] with length 0
goroutine 934 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:24 +0x64
github.com/charmbracelet/wish/recover.MiddlewareWithLogger.func2.1.1.1()
    /Users/user/go/pkg/mod/github.com/charmbracelet/wish@v1.3.2/recover/recover.go:39 +0x44
panic({0x103990940?, 0x140006946c0?})
    /usr/local/go/src/runtime/panic.go:770 +0x124
github.com/charmbracelet/soft-serve/pkg/ssh/cmd.branchCommand.branchDeleteCommand.func3(0x14000bf8c08?, {0x104237940, 0x0, 0x1033d0975?})
    /Users/user/src/soft-serve/pkg/ssh/cmd/branch.go:155 +0x380
github.com/spf13/cobra.(*Command).execute(0x14000bf8c08, {0x104237940, 0x0, 0x0})
    /Users/user/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x140005b3508)
    /Users/user/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
    /Users/user/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
    /Users/user/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1032
github.com/charmbracelet/soft-serve/pkg/ssh.CommandMiddleware.func1({0x103a114e0, 0x1400066e1a0})
    /Users/user/src/soft-serve/pkg/ssh/middleware.go:145 +0x990
github.com/charmbracelet/soft-serve/pkg/ssh.LoggingMiddleware.func1({0x103a114e0, 0x1400066e1a0})
    /Users/user/src/soft-serve/pkg/ssh/middleware.go:193 +0x630
github.com/charmbracelet/soft-serve/pkg/ssh.NewSSHServer.ContextMiddleware.func3.1({0x103a114e0, 0x1400066e1a0})
    /Users/user/src/soft-serve/pkg/ssh/middleware.go:68 +0x27c
github.com/charmbracelet/soft-serve/pkg/ssh.AuthenticationMiddleware.func1({0x103a114e0, 0x1400066e1a0})
    /Users/user/src/soft-serve/pkg/ssh/middleware.go:54 +0x100
github.com/charmbracelet/wish/recover.MiddlewareWithLogger.func2.1.1({0x103a002a0?, 0x14000774780?}, 0x14000c028a0?, {0x103a114e0?, 0x1400066e1a0?})
    /Users/user/go/pkg/mod/github.com/charmbracelet/wish@v1.3.2/recover/recover.go:43 +0x70
github.com/charmbracelet/wish/recover.MiddlewareWithLogger.func2.1({0x103a114e0, 0x1400066e1a0})
    /Users/user/go/pkg/mod/github.com/charmbracelet/wish@v1.3.2/recover/recover.go:44 +0x48
github.com/charmbracelet/ssh.(*session).handleRequests.func1()
    /Users/user/go/pkg/mod/github.com/charmbracelet/ssh@v0.0.0-20240301204039-e79ff702f5b3/session.go:274 +0x130
created by github.com/charmbracelet/ssh.(*session).handleRequests in goroutine 897
    /Users/user/go/pkg/mod/github.com/charmbracelet/ssh@v0.0.0-20240301204039-e79ff702f5b3/session.go:268 +0x518
```

Thank you for soft-serve!