### PR TITLE
feat: config supports toggling HTTP and Stats servers on/off (#594)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,9 @@ var binPath = "soft"
 
 // SSHConfig is the configuration for the SSH server.
 type SSHConfig struct {
+	// Enabled toggles the SSH server on/off
+	Enabled bool `env:"ENABLED" yaml:"enabled"`
+
 	// ListenAddr is the address on which the SSH server will listen.
 	ListenAddr string `env:"LISTEN_ADDR" yaml:"listen_addr"`
 
@@ -39,6 +42,9 @@ type SSHConfig struct {
 
 // GitConfig is the Git daemon configuration for the server.
 type GitConfig struct {
+	// Enabled toggles the Git daemon on/off
+	Enabled bool `env:"ENABLED" yaml:"enabled"`
+
 	// ListenAddr is the address on which the Git daemon will listen.
 	ListenAddr string `env:"LISTEN_ADDR" yaml:"listen_addr"`
 
@@ -57,6 +63,9 @@ type GitConfig struct {
 
 // HTTPConfig is the HTTP configuration for the server.
 type HTTPConfig struct {
+	// Enabled toggles the HTTP server on/off
+	Enabled bool `env:"ENABLED" yaml:"enabled"`
+
 	// ListenAddr is the address on which the HTTP server will listen.
 	ListenAddr string `env:"LISTEN_ADDR" yaml:"listen_addr"`
 
@@ -72,6 +81,9 @@ type HTTPConfig struct {
 
 // StatsConfig is the configuration for the stats server.
 type StatsConfig struct {
+	// Enabled toggles the Stats server on/off
+	Enabled bool `env:"ENABLED" yaml:"enabled"`
+
 	// ListenAddr is the address on which the stats server will listen.
 	ListenAddr string `env:"LISTEN_ADDR" yaml:"listen_addr"`
 }
@@ -165,21 +177,25 @@ func (c *Config) Environ() []string {
 		fmt.Sprintf("SOFT_SERVE_DATA_PATH=%s", c.DataPath),
 		fmt.Sprintf("SOFT_SERVE_NAME=%s", c.Name),
 		fmt.Sprintf("SOFT_SERVE_INITIAL_ADMIN_KEYS=%s", strings.Join(c.InitialAdminKeys, "\n")),
+		fmt.Sprintf("SOFT_SERVE_SSH_ENABLED=%t", c.SSH.Enabled),
 		fmt.Sprintf("SOFT_SERVE_SSH_LISTEN_ADDR=%s", c.SSH.ListenAddr),
 		fmt.Sprintf("SOFT_SERVE_SSH_PUBLIC_URL=%s", c.SSH.PublicURL),
 		fmt.Sprintf("SOFT_SERVE_SSH_KEY_PATH=%s", c.SSH.KeyPath),
 		fmt.Sprintf("SOFT_SERVE_SSH_CLIENT_KEY_PATH=%s", c.SSH.ClientKeyPath),
 		fmt.Sprintf("SOFT_SERVE_SSH_MAX_TIMEOUT=%d", c.SSH.MaxTimeout),
 		fmt.Sprintf("SOFT_SERVE_SSH_IDLE_TIMEOUT=%d", c.SSH.IdleTimeout),
+		fmt.Sprintf("SOFT_SERVE_GIT_ENABLED=%t", c.Git.Enabled),
 		fmt.Sprintf("SOFT_SERVE_GIT_LISTEN_ADDR=%s", c.Git.ListenAddr),
 		fmt.Sprintf("SOFT_SERVE_GIT_PUBLIC_URL=%s", c.Git.PublicURL),
 		fmt.Sprintf("SOFT_SERVE_GIT_MAX_TIMEOUT=%d", c.Git.MaxTimeout),
 		fmt.Sprintf("SOFT_SERVE_GIT_IDLE_TIMEOUT=%d", c.Git.IdleTimeout),
 		fmt.Sprintf("SOFT_SERVE_GIT_MAX_CONNECTIONS=%d", c.Git.MaxConnections),
+		fmt.Sprintf("SOFT_SERVE_HTTP_ENABLED=%t", c.HTTP.Enabled),
 		fmt.Sprintf("SOFT_SERVE_HTTP_LISTEN_ADDR=%s", c.HTTP.ListenAddr),
 		fmt.Sprintf("SOFT_SERVE_HTTP_TLS_KEY_PATH=%s", c.HTTP.TLSKeyPath),
 		fmt.Sprintf("SOFT_SERVE_HTTP_TLS_CERT_PATH=%s", c.HTTP.TLSCertPath),
 		fmt.Sprintf("SOFT_SERVE_HTTP_PUBLIC_URL=%s", c.HTTP.PublicURL),
+		fmt.Sprintf("SOFT_SERVE_STATS_ENABLED=%t", c.Stats.Enabled),
 		fmt.Sprintf("SOFT_SERVE_STATS_LISTEN_ADDR=%s", c.Stats.ListenAddr),
 		fmt.Sprintf("SOFT_SERVE_LOG_FORMAT=%s", c.Log.Format),
 		fmt.Sprintf("SOFT_SERVE_LOG_TIME_FORMAT=%s", c.Log.TimeFormat),
@@ -318,6 +334,7 @@ func DefaultConfig() *Config {
 		Name:     "Soft Serve",
 		DataPath: DefaultDataPath(),
 		SSH: SSHConfig{
+			Enabled:       true,
 			ListenAddr:    ":23231",
 			PublicURL:     "ssh://localhost:23231",
 			KeyPath:       filepath.Join("ssh", "soft_serve_host_ed25519"),
@@ -326,6 +343,7 @@ func DefaultConfig() *Config {
 			IdleTimeout:   10 * 60, // 10 minutes
 		},
 		Git: GitConfig{
+			Enabled:        true,
 			ListenAddr:     ":9418",
 			PublicURL:      "git://localhost",
 			MaxTimeout:     0,
@@ -333,10 +351,12 @@ func DefaultConfig() *Config {
 			MaxConnections: 32,
 		},
 		HTTP: HTTPConfig{
+			Enabled:    true,
 			ListenAddr: ":23232",
 			PublicURL:  "http://localhost:23232",
 		},
 		Stats: StatsConfig{
+			Enabled:    true,
 			ListenAddr: "localhost:23233",
 		},
 		Log: LogConfig{

--- a/testscript/script_test.go
+++ b/testscript/script_test.go
@@ -88,20 +88,21 @@ func TestScript(t *testing.T) {
 		UpdateScripts:       *update,
 		RequireExplicitExec: true,
 		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
-			"soft":                cmdSoft("admin", admin1.Signer()),
-			"usoft":               cmdSoft("user1", user1.Signer()),
-			"git":                 cmdGit(admin1Key),
-			"ugit":                cmdGit(user1Key),
-			"curl":                cmdCurl,
-			"mkfile":              cmdMkfile,
-			"envfile":             cmdEnvfile,
-			"readfile":            cmdReadfile,
-			"dos2unix":            cmdDos2Unix,
-			"new-webhook":         cmdNewWebhook,
-			"ensureserverrunning": cmdEnsureServerRunning,
-			"stopserver":          cmdStopserver,
-			"ui":                  cmdUI(admin1.Signer()),
-			"uui":                 cmdUI(user1.Signer()),
+			"soft":                   cmdSoft("admin", admin1.Signer()),
+			"usoft":                  cmdSoft("user1", user1.Signer()),
+			"git":                    cmdGit(admin1Key),
+			"ugit":                   cmdGit(user1Key),
+			"curl":                   cmdCurl,
+			"mkfile":                 cmdMkfile,
+			"envfile":                cmdEnvfile,
+			"readfile":               cmdReadfile,
+			"dos2unix":               cmdDos2Unix,
+			"new-webhook":            cmdNewWebhook,
+			"ensureserverrunning":    cmdEnsureServerRunning,
+			"ensureservernotrunning": cmdEnsureServerNotRunning,
+			"stopserver":             cmdStopserver,
+			"ui":                     cmdUI(admin1.Signer()),
+			"uui":                    cmdUI(user1.Signer()),
 		},
 		Setup: func(e *testscript.Env) error {
 			// Add binPath to PATH
@@ -121,6 +122,8 @@ func TestScript(t *testing.T) {
 			e.Setenv("DATA_PATH", data)
 			e.Setenv("SSH_PORT", fmt.Sprintf("%d", sshPort))
 			e.Setenv("HTTP_PORT", fmt.Sprintf("%d", httpPort))
+			e.Setenv("STATS_PORT", fmt.Sprintf("%d", statsPort))
+			e.Setenv("GIT_PORT", fmt.Sprintf("%d", gitPort))
 			e.Setenv("ADMIN1_AUTHORIZED_KEY", admin1.AuthorizedKey())
 			e.Setenv("ADMIN2_AUTHORIZED_KEY", admin2.AuthorizedKey())
 			e.Setenv("USER1_AUTHORIZED_KEY", user1.AuthorizedKey())
@@ -502,6 +505,32 @@ func cmdEnsureServerRunning(ts *testscript.TestScript, neg bool, args []string) 
 			conn.Close()
 			break
 		}
+	}
+}
+
+func cmdEnsureServerNotRunning(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) < 1 {
+		ts.Fatalf("Must supply a TCP port of one of the services to connect to. " +
+			"These are set as env vars as they are randomized. " +
+			"Example usage: \"cmdensureservernotrunning SSH_PORT\"\n" +
+			"Valid values for the env var: SSH_PORT|HTTP_PORT|GIT_PORT|STATS_PORT")
+	}
+
+	port := ts.Getenv(args[0])
+
+	// verify that the server is not up
+	addr := net.JoinHostPort("localhost", port)
+	for {
+		conn, _ := net.DialTimeout(
+			"tcp",
+			addr,
+			time.Second,
+		)
+		if conn != nil {
+			ts.Fatalf("server is running on port %s while it should not be running", port)
+			conn.Close()
+		}
+		break
 	}
 }
 

--- a/testscript/script_test.go
+++ b/testscript/script_test.go
@@ -34,6 +34,15 @@ var (
 	binPath string
 )
 
+func PrepareBuildCommand(binPath string) *exec.Cmd {
+	_, disableRaceSet := os.LookupEnv("DISABLE_RACE_CHECKS")
+	if disableRaceSet {
+		// don't add the -race flag
+		return exec.Command("go", "build", "-cover", "-o", binPath, filepath.Join("..", "cmd", "soft"))
+	}
+	return exec.Command("go", "build", "-race", "-cover", "-o", binPath, filepath.Join("..", "cmd", "soft"))
+}
+
 func TestMain(m *testing.M) {
 	tmp, err := os.MkdirTemp("", "soft-serve*")
 	if err != nil {
@@ -48,7 +57,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Build the soft binary with -cover flag.
-	cmd := exec.Command("go", "build", "-race", "-cover", "-o", binPath, filepath.Join("..", "cmd", "soft"))
+	cmd := PrepareBuildCommand(binPath)
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to build soft-serve binary: %s", err)
 		os.Exit(1)

--- a/testscript/testdata/anon-access.txtar
+++ b/testscript/testdata/anon-access.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # set settings
 soft settings allow-keyless true

--- a/testscript/testdata/config-servers-git_disabled.txtar
+++ b/testscript/testdata/config-servers-git_disabled.txtar
@@ -1,0 +1,18 @@
+# vi: set ft=conf
+
+# disable git listening
+env SOFT_SERVE_SSH_ENABLED=true
+env SOFT_SERVE_GIT_ENABLED=false
+env SOFT_SERVE_HTTP_ENABLED=true
+env SOFT_SERVE_STATS_ENABLED=true
+
+# start soft serve
+exec soft serve --sync-hooks &
+
+# wait for the ssh + other servers to come up
+ensureserverrunning SSH_PORT
+ensureserverrunning HTTP_PORT
+ensureserverrunning STATS_PORT
+
+# ensure that the disabled server is not running
+ensureservernotrunning GIT_PORT

--- a/testscript/testdata/config-servers-http_disabled.txtar
+++ b/testscript/testdata/config-servers-http_disabled.txtar
@@ -1,0 +1,19 @@
+# vi: set ft=conf
+
+# disable http listening
+env SOFT_SERVE_SSH_ENABLED=true
+env SOFT_SERVE_GIT_ENABLED=true
+env SOFT_SERVE_HTTP_ENABLED=false
+env SOFT_SERVE_STATS_ENABLED=true
+
+# start soft serve
+exec soft serve --sync-hooks &
+
+# wait for the ssh + other servers to come up
+ensureserverrunning SSH_PORT
+ensureserverrunning GIT_PORT
+ensureserverrunning STATS_PORT
+
+# ensure that the disabled server is not running
+ensureservernotrunning HTTP_PORT
+

--- a/testscript/testdata/config-servers-ssh_disabled.txtar
+++ b/testscript/testdata/config-servers-ssh_disabled.txtar
@@ -1,0 +1,18 @@
+# vi: set ft=conf
+
+# disable ssh listening
+env SOFT_SERVE_SSH_ENABLED=false
+env SOFT_SERVE_GIT_ENABLED=true
+env SOFT_SERVE_HTTP_ENABLED=true
+env SOFT_SERVE_STATS_ENABLED=true
+
+# start soft serve
+exec soft serve --sync-hooks &
+
+# wait for the git + other servers to come up
+ensureserverrunning GIT_PORT
+ensureserverrunning HTTP_PORT
+ensureserverrunning STATS_PORT
+
+# ensure that the disabled server is not running
+ensureservernotrunning SSH_PORT

--- a/testscript/testdata/config-servers-stats_disabled.txtar
+++ b/testscript/testdata/config-servers-stats_disabled.txtar
@@ -1,0 +1,18 @@
+# vi: set ft=conf
+
+# disable stats listening
+env SOFT_SERVE_SSH_ENABLED=true
+env SOFT_SERVE_GIT_ENABLED=true
+env SOFT_SERVE_HTTP_ENABLED=true
+env SOFT_SERVE_STATS_ENABLED=false
+
+# start soft serve
+exec soft serve --sync-hooks &
+
+# wait for the ssh + other servers to come up
+ensureserverrunning SSH_PORT
+ensureserverrunning GIT_PORT
+ensureserverrunning HTTP_PORT
+
+# ensure that the disabled server is not running
+ensureservernotrunning STATS_PORT

--- a/testscript/testdata/help.txtar
+++ b/testscript/testdata/help.txtar
@@ -3,8 +3,8 @@
 
 # start soft serve
 exec soft serve --sync-hooks &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 soft --help
 cmpenv stdout help.txt

--- a/testscript/testdata/http.txtar
+++ b/testscript/testdata/http.txtar
@@ -8,8 +8,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create user
 soft user create user1 --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/jwt.txtar
+++ b/testscript/testdata/jwt.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create user
 soft user create user1 --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/mirror.txtar
+++ b/testscript/testdata/mirror.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # import a repo
 soft repo import --mirror charmbracelet/catwalk https://github.com/charmbracelet/catwalk.git

--- a/testscript/testdata/repo-blob.txtar
+++ b/testscript/testdata/repo-blob.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo1

--- a/testscript/testdata/repo-collab.txtar
+++ b/testscript/testdata/repo-collab.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # setup
 soft repo import test https://github.com/charmbracelet/catwalk.git

--- a/testscript/testdata/repo-commit.txtar
+++ b/testscript/testdata/repo-commit.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo import basic1 https://github.com/git-fixtures/basic

--- a/testscript/testdata/repo-create.txtar
+++ b/testscript/testdata/repo-create.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo1 -d 'description' -H -p -n 'repo11'

--- a/testscript/testdata/repo-delete.txtar
+++ b/testscript/testdata/repo-delete.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 soft repo create repo1
 soft repo create repo-to-delete

--- a/testscript/testdata/repo-import.txtar
+++ b/testscript/testdata/repo-import.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # import private
 soft repo import --private repo1 https://github.com/charmbracelet/catwalk.git

--- a/testscript/testdata/repo-perms.txtar
+++ b/testscript/testdata/repo-perms.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo & user1 with admin
 soft repo create repo1 -p

--- a/testscript/testdata/repo-push.txtar
+++ b/testscript/testdata/repo-push.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo-empty -d 'description' -H -p -n 'repo-empty'

--- a/testscript/testdata/repo-tree.txtar
+++ b/testscript/testdata/repo-tree.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo1

--- a/testscript/testdata/repo-webhooks.txtar
+++ b/testscript/testdata/repo-webhooks.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo-123

--- a/testscript/testdata/set-username.txtar
+++ b/testscript/testdata/set-username.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # get original username
 soft info

--- a/testscript/testdata/settings.txtar
+++ b/testscript/testdata/settings.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # check default allow-keyless
 soft settings allow-keyless true

--- a/testscript/testdata/ssh-lfs.txtar
+++ b/testscript/testdata/ssh-lfs.txtar
@@ -8,8 +8,8 @@ skip 'breaks with git-lfs 3.5.1'
 env SOFT_SERVE_LFS_SSH_ENABLED=true
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a user
 soft user create foo --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/ssh.txtar
+++ b/testscript/testdata/ssh.txtar
@@ -4,8 +4,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a user
 soft user create foo --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/token.txtar
+++ b/testscript/testdata/token.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create user
 soft user create user1 --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/ui-home.txtar
+++ b/testscript/testdata/ui-home.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # test repositories tab
 ui '"    q"'

--- a/testscript/testdata/user_management.txtar
+++ b/testscript/testdata/user_management.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # add key to admin
 soft user add-pubkey admin "$ADMIN2_AUTHORIZED_KEY"


### PR DESCRIPTION
This changes the behavior of the stats server and git server but I assume most people don't want that by default.
The ssh/http servers are most likely the primary ones?