### PR TITLE
fix: test framework supports ensuring specific port is open

### DIFF
--- a/testscript/testdata/anon-access.txtar
+++ b/testscript/testdata/anon-access.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # set settings
 soft settings allow-keyless true

--- a/testscript/testdata/help.txtar
+++ b/testscript/testdata/help.txtar
@@ -3,8 +3,8 @@
 
 # start soft serve
 exec soft serve --sync-hooks &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 soft --help
 cmpenv stdout help.txt

--- a/testscript/testdata/http.txtar
+++ b/testscript/testdata/http.txtar
@@ -8,8 +8,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create user
 soft user create user1 --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/jwt.txtar
+++ b/testscript/testdata/jwt.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create user
 soft user create user1 --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/mirror.txtar
+++ b/testscript/testdata/mirror.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # import a repo
 soft repo import --mirror charmbracelet/catwalk https://github.com/charmbracelet/catwalk.git

--- a/testscript/testdata/repo-blob.txtar
+++ b/testscript/testdata/repo-blob.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo1

--- a/testscript/testdata/repo-collab.txtar
+++ b/testscript/testdata/repo-collab.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # setup
 soft repo import test https://github.com/charmbracelet/catwalk.git

--- a/testscript/testdata/repo-commit.txtar
+++ b/testscript/testdata/repo-commit.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo import basic1 https://github.com/git-fixtures/basic

--- a/testscript/testdata/repo-create.txtar
+++ b/testscript/testdata/repo-create.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo1 -d 'description' -H -p -n 'repo11'

--- a/testscript/testdata/repo-delete.txtar
+++ b/testscript/testdata/repo-delete.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 soft repo create repo1
 soft repo create repo-to-delete

--- a/testscript/testdata/repo-import.txtar
+++ b/testscript/testdata/repo-import.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # import private
 soft repo import --private repo1 https://github.com/charmbracelet/catwalk.git

--- a/testscript/testdata/repo-perms.txtar
+++ b/testscript/testdata/repo-perms.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo & user1 with admin
 soft repo create repo1 -p

--- a/testscript/testdata/repo-push.txtar
+++ b/testscript/testdata/repo-push.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo-empty -d 'description' -H -p -n 'repo-empty'

--- a/testscript/testdata/repo-tree.txtar
+++ b/testscript/testdata/repo-tree.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo1

--- a/testscript/testdata/repo-webhooks.txtar
+++ b/testscript/testdata/repo-webhooks.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a repo
 soft repo create repo-123

--- a/testscript/testdata/set-username.txtar
+++ b/testscript/testdata/set-username.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # get original username
 soft info

--- a/testscript/testdata/settings.txtar
+++ b/testscript/testdata/settings.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # check default allow-keyless
 soft settings allow-keyless true

--- a/testscript/testdata/ssh-lfs.txtar
+++ b/testscript/testdata/ssh-lfs.txtar
@@ -8,8 +8,8 @@ skip 'breaks with git-lfs 3.5.1'
 env SOFT_SERVE_LFS_SSH_ENABLED=true
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a user
 soft user create foo --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/ssh.txtar
+++ b/testscript/testdata/ssh.txtar
@@ -4,8 +4,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create a user
 soft user create foo --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/token.txtar
+++ b/testscript/testdata/token.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # create user
 soft user create user1 --key "$USER1_AUTHORIZED_KEY"

--- a/testscript/testdata/ui-home.txtar
+++ b/testscript/testdata/ui-home.txtar
@@ -2,8 +2,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # test repositories tab
 ui '"    q"'

--- a/testscript/testdata/user_management.txtar
+++ b/testscript/testdata/user_management.txtar
@@ -5,8 +5,8 @@
 
 # start soft serve
 exec soft serve &
-# wait for server to start
-waitforserver
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
 
 # add key to admin
 soft user add-pubkey admin "$ADMIN2_AUTHORIZED_KEY"


### PR DESCRIPTION
The generic "waitforserver" has been renamed to
"ensureserverrunning".

This command now also takes an argument which denotes which environment variable to pick the port from.

This is needed as the ports are randomized by the test.