### PR TITLE
fix: prevent path traversal attacks

### DIFF
--- a/pkg/ssh/cmd/cmd.go
+++ b/pkg/ssh/cmd/cmd.go
@@ -172,7 +172,7 @@ func checkIfAdmin(cmd *cobra.Command, args []string) error {
 func checkIfCollab(cmd *cobra.Command, args []string) error {
 	var repo string
 	if len(args) > 0 {
-		repo = args[0]
+		repo = utils.SanitizeRepo(args[0])
 	}
 
 	ctx := cmd.Context()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,12 +9,15 @@ import (
 
 // SanitizeRepo returns a sanitized version of the given repository name.
 func SanitizeRepo(repo string) string {
+	// We need to use an absolute path for the path to be cleaned correctly.
 	repo = strings.TrimPrefix(repo, "/")
+	repo = "/" + repo
+
 	// We're using path instead of filepath here because this is not OS dependent
 	// looking at you Windows
 	repo = path.Clean(repo)
 	repo = strings.TrimSuffix(repo, ".git")
-	return repo
+	return repo[1:]
 }
 
 // ValidateUsername returns an error if any of the given usernames are invalid.


### PR DESCRIPTION
This commit fixes a path traversal vulnerability in the repository management code. The `SanitizeRepo` function now correctly returns a sanitized version of the given repository name. It uses an absolute path along with `path.Clean` to ensure that the path is cleaned before being used.