### PR TITLE
feat(backend): Support README files in the second-depth directories

### DIFF
--- a/pkg/backend/utils.go
+++ b/pkg/backend/utils.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"path/filepath"
+
 	"github.com/charmbracelet/soft-serve/git"
 	"github.com/charmbracelet/soft-serve/pkg/proto"
 )
@@ -16,8 +18,13 @@ func LatestFile(r proto.Repository, ref *git.Reference, pattern string) (string,
 }
 
 // Readme returns the repository's README.
+// It searches in priority order: root, .github, docs.
 func Readme(r proto.Repository, ref *git.Reference) (readme string, path string, err error) {
-	pattern := "[rR][eE][aA][dD][mM][eE]*"
-	readme, path, err = LatestFile(r, ref, pattern)
+	for _, dir := range []string{".", ".github", "docs"} {
+		readme, path, err = LatestFile(r, ref, filepath.Join(dir, "[rR][eE][aA][dD][mM][eE]*"))
+		if err == nil {
+			return
+		}
+	}
 	return
 }

--- a/testscript/script_test.go
+++ b/testscript/script_test.go
@@ -539,6 +539,7 @@ func cmdEnsureServerRunning(ts *testscript.TestScript, neg bool, args []string) 
 
 	// verify that the server is up
 	addr := net.JoinHostPort("localhost", port)
+	deadline := time.Now().Add(30 * time.Second)
 	for {
 		conn, _ := net.DialTimeout( //nolint:noctx
 			"tcp",
@@ -550,6 +551,10 @@ func cmdEnsureServerRunning(ts *testscript.TestScript, neg bool, args []string) 
 			conn.Close()
 			break
 		}
+		if time.Now().After(deadline) {
+			ts.Fatalf("server on port %s did not start within 30 seconds", port)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
close #634

Repositories will check the README file in these directories.

- `/`
- `/docs/`
- `/.github/`

This change is because many other Git platforms support it as well.