### PR TITLE
Fix repo URL width calculation.

### DIFF
--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -340,13 +340,13 @@ func (r *Repo) headerView() string {
 		)
 	}
 	urlStyle := r.common.Styles.URLStyle.
-		Width(r.common.Width - lipgloss.Width(desc) - 1).
+		Width(r.common.Width - lipgloss.Width(header) - 1).
 		Align(lipgloss.Right)
 	var url string
 	if cfg := r.common.Config(); cfg != nil {
 		url = r.common.CloneCmd(cfg.SSH.PublicURL, r.selectedRepo.Name())
 	}
-	url = common.TruncateString(url, r.common.Width-lipgloss.Width(desc)-1)
+	url = common.TruncateString(url, r.common.Width-lipgloss.Width(header)-1)
 	url = r.common.Zone.Mark(
 		fmt.Sprintf("%s-url", r.selectedRepo.Name()),
 		urlStyle.Render(url),


### PR DESCRIPTION
Previous code only used description width to calculate remaining space.

At that point the description has already been merged into the header so the header can be used to calculate remaining width correctly.

Fixes #521 

E.G.

Before:
![Screenshot from 2025-01-17 13-22-20](https://github.com/user-attachments/assets/d338bec8-81f0-4eff-be67-1d8019bde383)

After:
![Screenshot from 2025-01-17 13-21-06](https://github.com/user-attachments/assets/7a1b3df5-a343-4d1a-81ee-c57bd5edbba5)

