### PR TITLE
feat: add support for certificate reloading upon SIGHUP

### DIFF
--- a/pkg/web/certreloader.go
+++ b/pkg/web/certreloader.go
@@ -1,0 +1,68 @@
+package web
+
+import (
+	"crypto/tls"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/charmbracelet/log"
+)
+
+// CertReloader is responsible for reloading TLS certificates when a SIGHUP signal is received.
+type CertReloader struct {
+	certMu   sync.RWMutex
+	cert     *tls.Certificate
+	certPath string
+	keyPath  string
+}
+
+// NewCertReloader creates a new CertReloader that watches for SIGHUP signals.
+func NewCertReloader(certPath, keyPath string, logger *log.Logger) (*CertReloader, error) {
+	reloader := &CertReloader{
+		certPath: certPath,
+		keyPath:  keyPath,
+	}
+
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	reloader.cert = &cert
+
+	go func() {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGHUP)
+		for range sigChan {
+			logger.Info("attempting to reload TLS certificate and key", "cert", certPath, "key", keyPath)
+			if err := reloader.maybeReload(); err != nil {
+				logger.Error("failed to reload TLS certificate, keeping old certificate", "err", err)
+			}
+		}
+	}()
+
+	return reloader, nil
+}
+
+// maybeReload attempts to reload the certificate and key.
+func (cr *CertReloader) maybeReload() error {
+	newCert, err := tls.LoadX509KeyPair(cr.certPath, cr.keyPath)
+	if err != nil {
+		return err
+	}
+
+	cr.certMu.Lock()
+	defer cr.certMu.Unlock()
+	cr.cert = &newCert
+	return nil
+}
+
+// GetCertificateFunc returns a function that can be used with tls.Config.GetCertificate.
+func (cr *CertReloader) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		cr.certMu.RLock()
+		defer cr.certMu.RUnlock()
+		return cr.cert, nil
+	}
+}


### PR DESCRIPTION
This PR adds cert reloading on SIGHUP by:

using tis.Config's GetCertificate function instead of using ListenAndServeTLS to manage certificate
reload certificate from config path on receiving SIGHUP
if reloading fails continue to use the original certificate

Closes: #686 

How I tested this:

1. Create a self signed key pair using openssl (expiry ~10 years)
`openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3600 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=Old/OU=CompanySectionName/CN=CommonNameOrHostname"`

2. Check certificate expiry using curl
`curl "https://127.0.0.1:23232" -vk 2>&1 | grep "expire date"`

3. Generate a new keypair with 30 day expiry and verify that its reloaded on SIGHUP
![image](https://github.com/user-attachments/assets/c3ead4f8-2f53-4247-9d39-aee3c2295773)
