### PR TITLE
fix(ui): help menu on file list view

### DIFF
--- a/pkg/ui/keymap/keymap.go
+++ b/pkg/ui/keymap/keymap.go
@@ -198,7 +198,7 @@ func DefaultKeyMap() *KeyMap {
 			"right",
 		),
 		key.WithHelp(
-			"→",
+			"→/l",
 			"select",
 		),
 	)
@@ -210,7 +210,7 @@ func DefaultKeyMap() *KeyMap {
 			"backspace",
 		),
 		key.WithHelp(
-			"←",
+			"←/h",
 			"back",
 		),
 	)

--- a/pkg/ui/pages/repo/files.go
+++ b/pkg/ui/pages/repo/files.go
@@ -151,17 +151,7 @@ func (f *Files) ShortHelp() []key.Binding {
 func (f *Files) FullHelp() [][]key.Binding {
 	b := make([][]key.Binding, 0)
 	copyKey := f.common.KeyMap.Copy
-	actionKeys := []key.Binding{
-		copyKey,
-	}
-	if !f.code.UseGlamour {
-		actionKeys = append(actionKeys, lineNo)
-	}
-	actionKeys = append(actionKeys, blameView)
-	if common.IsFileMarkdown(f.currentContent.content, f.currentContent.ext) &&
-		!f.blameView {
-		actionKeys = append(actionKeys, preview)
-	}
+	actionKeys := []key.Binding{}
 	switch f.activeView {
 	case filesViewFiles:
 		copyKey.SetHelp("c", "copy name")
@@ -183,6 +173,14 @@ func (f *Files) FullHelp() [][]key.Binding {
 			},
 		}...)
 	case filesViewContent:
+		if !f.code.UseGlamour {
+			actionKeys = append(actionKeys, lineNo)
+		}
+		actionKeys = append(actionKeys, blameView)
+		if common.IsFileMarkdown(f.currentContent.content, f.currentContent.ext) &&
+			!f.blameView {
+			actionKeys = append(actionKeys, preview)
+		}
 		copyKey.SetHelp("c", "copy content")
 		k := f.code.KeyMap
 		b = append(b, []key.Binding{
@@ -203,6 +201,9 @@ func (f *Files) FullHelp() [][]key.Binding {
 			},
 		}...)
 	}
+	actionKeys = append([]key.Binding{
+		copyKey,
+	}, actionKeys...)
 	return append(b, actionKeys)
 }
 


### PR DESCRIPTION
### Describe your changes

Minor changes to some help messages, particularly small improvements to the file list view help.

Specifically, code existed to change the help text on the "(c) copy text" key to indicate what would be copied (filename or content), but this code wasn't effecting the change, likely due to copying values into the slice directly instead of pointers. Also, `blame` and line number toggles were being added to the help list, despite those keys having different effects the file list view. Finally, this makes explicit that h and l keys can be used to ascend/descend the file hierarchy in the file list view.


- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

