### PR TITLE
Yank the patch/diff to clipboard

### DIFF
--- a/pkg/ui/pages/repo/log.go
+++ b/pkg/ui/pages/repo/log.go
@@ -117,9 +117,12 @@ func (l *Log) ShortHelp() []key.Binding {
 			copyKey,
 		}
 	case logViewDiff:
+		copyKey := l.common.KeyMap.Copy
+		copyKey.SetHelp("c", "copy diff")
 		return []key.Binding{
 			l.common.KeyMap.UpDown,
 			l.common.KeyMap.BackItem,
+			copyKey,
 			l.common.KeyMap.GotoTop,
 			l.common.KeyMap.GotoBottom,
 		}
@@ -154,9 +157,12 @@ func (l *Log) FullHelp() [][]key.Binding {
 			},
 		}...)
 	case logViewDiff:
+		copyKey := l.common.KeyMap.Copy
+		copyKey.SetHelp("c", "copy diff")
 		k := l.vp.KeyMap
 		b = append(b, []key.Binding{
 			l.common.KeyMap.BackItem,
+			copyKey,
 		})
 		b = append(b, [][]key.Binding{
 			{
@@ -252,6 +258,10 @@ func (l *Log) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				switch {
 				case key.Matches(kmsg, l.common.KeyMap.BackItem):
 					l.goBack()
+				case key.Matches(kmsg, l.common.KeyMap.Copy):
+					if l.currentDiff != nil {
+						cmds = append(cmds, copyCmd(l.currentDiff.Patch(), "Commit diff copied to clipboard"))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Describe your changes

When viewing the diff for a specific commit, pressing `c` will yank the patch to the clipboard allowing users to more easily patch locally.

This is an extension of the `c` keystroke which already copies the `git clone ...` command when viewing all repos and copies the commit hash while viewing commit history. 

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my code

### If this is a feature

Not exactly, I just builds upon a feature that already exists (clipboard).
