### PR TITLE
feat: add readiness and liveness probes for self healing

### DIFF
--- a/pkg/web/health.go
+++ b/pkg/web/health.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/charmbracelet/log/v2"
 	"github.com/charmbracelet/soft-serve/pkg/db"
 	"github.com/gorilla/mux"
 )
@@ -21,15 +22,11 @@ func getLiveness(w http.ResponseWriter, _ *http.Request) {
 
 func getReadiness(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
 	db := db.FromContext(ctx)
 
-	errs := make([]error, 0)
-	err := db.PingContext(ctx)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("readiness check failed: %w", err))
-	}
-
-	if len(errs) > 0 {
+	if err := db.PingContext(ctx); err != nil {
+		logger.Error("error getting db readiness", "err", err)
 		renderStatus(http.StatusServiceUnavailable)(w, nil)
 		return
 	}

--- a/pkg/web/health.go
+++ b/pkg/web/health.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/charmbracelet/log/v2"

--- a/pkg/web/health.go
+++ b/pkg/web/health.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/charmbracelet/soft-serve/pkg/db"
+	"github.com/gorilla/mux"
+)
+
+// HealthController registers the health check routes for the web server.
+func HealthController(_ context.Context, r *mux.Router) {
+	r.HandleFunc("/livez", getLiveness)
+	r.HandleFunc("/readyz", getReadiness)
+}
+
+func getLiveness(w http.ResponseWriter, _ *http.Request) {
+	renderStatus(http.StatusOK)(w, nil)
+}
+
+func getReadiness(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	db := db.FromContext(ctx)
+
+	errs := make([]error, 0)
+	err := db.PingContext(ctx)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("readiness check failed: %w", err))
+	}
+
+	if len(errs) > 0 {
+		renderStatus(http.StatusServiceUnavailable)(w, nil)
+		return
+	}
+
+	renderStatus(http.StatusOK)(w, nil)
+}

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -14,6 +14,9 @@ func NewRouter(ctx context.Context) http.Handler {
 	logger := log.FromContext(ctx).WithPrefix("http")
 	router := mux.NewRouter()
 
+	// Health routes
+	HealthController(ctx, router)
+
 	// Git routes
 	GitController(ctx, router)
 


### PR DESCRIPTION
### Describe your changes

I am running softserve in a k8s cluster and couldn't find an easy way to do liveness and readiness probes. 

I have added the standard k8s healthcheck paths (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) adding a db ping as a prerequisite to readiness, possibly the git server should be added as well? 

I have it running in my clusters from a build of my fork and am happy with this. But figured I would offer the patch upstream if desired. I did not create a discussion for this as i am not sure if this counts as a full "feature." But I can of course create one if desired. 

```bash
➜ k get deploy -n soft-serve soft-serve -oyaml | yq '.spec.template.spec.containers[].image'
ghcr.io/jay-madden/soft-serve:v0.0.1

➜ k get deploy -n soft-serve soft-serve -oyaml | yq '.spec.template.spec.containers[].livenessProbe'
failureThreshold: 3
httpGet:
  path: /livez
  port: 23232
  scheme: HTTP
initialDelaySeconds: 30
periodSeconds: 20
successThreshold: 1
timeoutSeconds: 1

➜ k get deploy -n soft-serve soft-serve -oyaml | yq '.spec.template.spec.containers[].readinessProbe'
failureThreshold: 3
httpGet:
  path: /readyz
  port: 23232
  scheme: HTTP
initialDelaySeconds: 10
periodSeconds: 15
successThreshold: 1
timeoutSeconds: 1

➜ k get pods -n soft-serve
NAME                          READY   STATUS    RESTARTS   AGE
soft-serve-7688ff745d-tkddw   1/1     Running   0          5m25s
softserve-db-1                1/1     Running   0          6d17h

➜ k logs -n soft-serve soft-serve-7688ff745d-tkddw
{"time":"2025-08-17 17:21:09","level":"debug","prefix":"cron","msg":"start"}
{"time":"2025-08-17 17:21:09","level":"debug","prefix":"cron","msg":"schedule","now":"2025-08-17 17:21:09.220701321 +0000 UTC","entry":1,"next":"2025-08-17 17:31:09 +0000 UTC"}
{"time":"2025-08-17 17:21:09","prefix":"server","msg":"Starting SSH server","addr":":23231"}
{"time":"2025-08-17 17:21:09","prefix":"server","msg":"Starting Git daemon","addr":":9418"}
{"time":"2025-08-17 17:21:09","prefix":"server","msg":"Starting HTTP server","addr":":23232"}
{"time":"2025-08-17 17:21:09","prefix":"server","msg":"Starting Stats server","addr":"localhost:23233"}
{"time":"2025-08-17 17:21:25","level":"debug","prefix":"http","msg":"request","method":"GET","path":"/readyz","addr":"10.42.0.1:44040"}
{"time":"2025-08-17 17:21:25","level":"debug","prefix":"http","msg":"response","status":"200 OK","bytes":"6 B"}
{"time":"2025-08-17 17:21:40","level":"debug","prefix":"http","msg":"request","method":"GET","path":"/readyz","addr":"10.42.0.1:58024"}
{"time":"2025-08-17 17:21:40","level":"debug","prefix":"http","msg":"response","status":"200 OK","bytes":"6 B"}
{"time":"2025-08-17 17:21:45","level":"debug","prefix":"http","msg":"request","method":"GET","path":"/livez","addr":"10.42.0.1:58034"}
{"time":"2025-08-17 17:21:45","level":"debug","prefix":"http","msg":"response","status":"200 OK","bytes":"6 B"}
{"time":"2025-08-17 17:21:55","level":"debug","prefix":"http","msg":"request","method":"GET","path":"/readyz","addr":"10.42.0.1:53100"}
{"time":"2025-08-17 17:21:55","level":"debug","prefix":"http","msg":"response","status":"200 OK","bytes":"6 B"}
{"time":"2025-08-17 17:22:05","level":"debug","prefix":"http","msg":"request","method":"GET","path":"/livez","addr":"10.42.0.1:50154"}
{"time":"2025-08-17 17:22:05","level":"debug","prefix":"http","msg":"response","status":"200 OK","bytes":"6 B"}
```

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
