### PR TITLE
feat: add commit and ref counters to repo tab view

### DIFF
--- a/pkg/ui/components/tabs/tabs.go
+++ b/pkg/ui/components/tabs/tabs.go
@@ -108,6 +108,13 @@ func (t *Tabs) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return t, tea.Batch(cmds...)
 }
 
+// ResetTabNames resets all tab names to their IDs.
+func (t *Tabs) ResetTabNames() {
+	for i := range t.tabs {
+		t.tabs[i].Value = t.tabs[i].ID
+	}
+}
+
 // View implements tea.Model.
 func (t *Tabs) View() string {
 	s := strings.Builder{}

--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -216,7 +216,6 @@ func (r *Repo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, r.updateTabComponent(&Readme{}, msg))
 	case FileItemsMsg, FileContentMsg:
 		cmds = append(cmds, r.updateTabComponent(&Files{}, msg))
-	case LogCommitMsg:
 	case LogItemsMsg, LogDiffMsg, LogCountMsg:
 		log := &Log{}
 		if lim, ok := msg.(LogItemsMsg); ok {

--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -68,7 +68,7 @@ func New(c common.Common, comps ...common.TabComponent) *Repo {
 		ts = append(ts, c.TabName())
 	}
 	c.Logger = c.Logger.WithPrefix("ui.repo")
-	tb := tabs.NewTabs(c, ts)
+	tb := tabs.New(c, ts)
 	// Make sure the order matches the order of tab constants above.
 	s := spinner.New(spinner.WithSpinner(spinner.Dot),
 		spinner.WithStyle(c.Styles.Spinner))
@@ -219,8 +219,8 @@ func (r *Repo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LogCommitMsg:
 	case LogItemsMsg, LogDiffMsg, LogCountMsg:
 		log := &Log{}
-		if lcm, ok := msg.(LogCountMsg); ok {
-			msg := tabs.SetTabValueMsg{ID: log.TabName(), Value: fmt.Sprintf("Commits (%d)", int64(lcm))}
+		if lim, ok := msg.(LogItemsMsg); ok {
+			msg := tabs.SetTabValueMsg{ID: log.TabName(), Value: fmt.Sprintf("Commits (%d)", len(lim))}
 			t, cmd := r.tabs.Update(msg)
 			r.tabs = t.(*tabs.Tabs)
 			if cmd != nil {

--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -139,6 +139,9 @@ func (r *Repo) FullHelp() [][]key.Binding {
 func (r *Repo) Init() tea.Cmd {
 	r.state = loadingState
 	r.activeTab = 0
+	// Reset the tab names on every init so that we do not
+	// briefly show incorrect counts when navigating between repos
+	r.tabs.ResetTabNames()
 	return tea.Batch(
 		r.tabs.Init(),
 		r.statusbar.Init(),


### PR DESCRIPTION
One of the main things I look for information wise when browsing repos is how many commits/branches it has. Softserve didnt easily show me that so i went ahead and added it to the tab view where it felt natural. 

I am currently running this happily on my forked build on my own server, but I figured I would offer the patch upstream as well. I haven't created a discussion but I can create one if needed?

Example:
<img width="585" height="183" alt="image" src="https://github.com/user-attachments/assets/d6f9ffad-d59c-4c4b-905c-dc92bde33b3b" />

The tab handling is a bit odd in that its a single tab instance for all repos, so i added the `ResetTabNames()` to the init to prevent other repos counts from showing up on new repos. It's not my favorite way to do it but short of making all repos their own "instance" of repo i think it's workable enough. 


- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
