### PR TITLE
docs: fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ You can check with the following:
 $ find ~/.ssh/id_*.pub -exec ssh-keygen -l -f {} \;
 ```
 
-If you’re curious about the inner workings of this problem have a look at:
+If you’re curious about the inner workings of this problem, have a look at:
 
 - https://github.com/golang/go/issues/37278
 - https://go-review.googlesource.com/c/crypto/+/220037


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Summary
- Add a comma for clarity in the README.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/charmbracelet/soft-serve/contribute

## Validation/testing
- Not run (docs change only)
