### PR TITLE
fix(git): fix stderr error var, add WaitDelay, handle context cancellation

### DIFF
--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"charm.land/log/v2"
 )
@@ -57,8 +58,27 @@ func (s Service) Handler(ctx context.Context, cmd ServiceCommand) error {
 type ServiceHandler func(ctx context.Context, cmd ServiceCommand) error
 
 // gitServiceHandler is the default service handler using the git binary.
+//
+// Deadline invariant: the ctx passed here must be cancellation-only — it must
+// NOT carry a context.WithDeadline or context.WithTimeout. All three transport
+// callers (SSH via gliderlabs/ssh, git daemon via pkg/daemon, HTTP via
+// net/http) enforce timeouts by calling conn.SetDeadline on the underlying
+// net.Conn, NOT by attaching a deadline to the context. If a caller were ever
+// changed to pass a deadline-carrying context, exec.CommandContext would kill
+// the git subprocess when the deadline expires, potentially corrupting an
+// in-progress push. In that case, replace ctx with a context.WithCancelCause
+// derived from context.Background() that mirrors parent cancellation but not
+// DeadlineExceeded.
 func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) error {
+	// NOTE: ctx is cancellation-only (derived from context.Background via
+	// context.WithCancel). SSH and git-daemon timeouts fire as net.Conn
+	// deadline errors, not context deadlines — so no deadline can reach here
+	// and kill a long-running push or clone mid-transfer.
 	cmd := exec.CommandContext(ctx, "git")
+	// WaitDelay bounds how long we wait for stdin/stdout pipe goroutines to
+	// finish after the git process has already been killed (e.g. by context
+	// cancellation). It does NOT impose a timeout on running git operations.
+	cmd.WaitDelay = 30 * time.Second
 	cmd.Dir = scmd.Dir
 	cmd.Args = append(cmd.Args, []string{
 		// Enable partial clones
@@ -125,8 +145,11 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 	if scmd.Stdin != nil {
 		go func() {
 			defer stdin.Close() //nolint: errcheck
-			if _, err := io.Copy(stdin, scmd.Stdin); err != nil {
-				log.Errorf("gitServiceHandler: failed to copy stdin: %v", err)
+			if _, err := io.Copy(stdin, scmd.Stdin); err != nil && ctx.Err() == nil {
+				// Broken-pipe here is normal: git read all it needed and exited,
+				// cmd.Wait() closed the write end of the pipe before the client
+				// finished sending. Log at Debug to avoid spurious error noise.
+				log.FromContext(ctx).Debug("gitServiceHandler: stdin copy ended", "err", err)
 			}
 		}()
 	}
@@ -136,7 +159,7 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, err := io.Copy(scmd.Stdout, stdout); err != nil {
+			if _, err := io.Copy(scmd.Stdout, stdout); err != nil && ctx.Err() == nil {
 				log.Errorf("gitServiceHandler: failed to copy stdout: %v", err)
 			}
 		}()
@@ -147,7 +170,7 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, erro := io.Copy(scmd.Stderr, stderr); err != nil {
+			if _, erro := io.Copy(scmd.Stderr, stderr); erro != nil && ctx.Err() == nil {
 				log.Errorf("gitServiceHandler: failed to copy stderr: %v", erro)
 			}
 		}()
@@ -159,12 +182,39 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 	wg.Wait()
 
 	err = cmd.Wait()
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return ErrInvalidRepo
-	} else if err != nil {
+	if err != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return fmt.Errorf("%s: %s", exitErr, exitErr.Stderr)
+		// Note: errors.As correctly unwraps through errors.Join, which Go 1.20+
+		// uses when cmd.WaitDelay fires (joining the ExitError with a timeout
+		// error). Verified: errors.As(errors.Join(exitErr, timeoutErr), &exitErr)
+		// returns true. So the suppression path below is safe even when WaitDelay
+		// wraps the ExitError via errors.Join.
+		if errors.As(err, &exitErr) {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				// Process exited because context was cancelled — client disconnected
+				// or server is shutting down. Expected; not worth surfacing.
+				// We do not gate on ExitCode()==-1: on Unix a signal-killed process
+				// has no exit code (-1), but on Windows TerminateProcess sets exit
+				// code 1. Checking ctx.Err() alone is portable across both.
+				log.FromContext(ctx).Debug("git process exited on context cancellation", "service", svc.Name())
+				return nil
+			}
+			// When WaitDelay fires alongside a non-zero exit, cmd.Wait returns
+			// errors.Join(exitErr, exec.ErrWaitDelay). Strip the WaitDelay noise
+			// so callers see a clean exit-status error, not an internal timeout.
+			retErr := error(exitErr)
+			if len(exitErr.Stderr) > 0 {
+				retErr = fmt.Errorf("%w: %s", exitErr, exitErr.Stderr)
+			}
+			return retErr
+		} else if errors.Is(err, exec.ErrWaitDelay) {
+			// WaitDelay (30s) expired before pipe goroutines drained. This branch
+			// is only reached when there is no accompanying ExitError (i.e. git
+			// exited 0 but the client read the pipe slowly). The git command
+			// succeeded; the drain timeout is an internal bookkeeping detail, not
+			// a caller-visible error.
+			log.FromContext(ctx).Debug("git pipe drain timed out", "service", svc.Name())
+			return nil
 		}
 
 		return err


### PR DESCRIPTION
## Summary

Four bugs in `gitServiceHandler` (`pkg/git/service.go`):

### 1. Stderr goroutine checks wrong variable (silent error loss)

```go
// BEFORE (broken)
if _, erro := io.Copy(scmd.Stderr, stderr); err != nil {  // checks outer err, always nil
    log.Errorf("...: %v", erro)
}

// AFTER (fixed)
if _, erro := io.Copy(scmd.Stderr, stderr); erro != nil && ctx.Err() == nil {
    log.Errorf("...: %v", erro)
}
```

`err` is the outer package-level variable, which is `nil` after all pipe setups succeed. Stderr copy errors were silently swallowed.

### 2. Missing WaitDelay → zombie git processes (#797)

Without `WaitDelay`, if `io.Copy` goroutines block after git is killed (context cancelled), `wg.Wait()` blocks indefinitely and `cmd.Wait()` is never called, leaving git as a zombie process. Added `cmd.WaitDelay = 30 * time.Second` to bound drain time.

### 3. Spurious error logs on client disconnect

`io.Copy` on stdin/stdout/stderr errors with broken-pipe/EOF when the SSH session closes normally. These are expected and were logged at Error level. Added `ctx.Err() == nil` guard to suppress them.

### 4. Dead `os.ErrNotExist` check after `cmd.Wait()`

`cmd.Start()` returns `os.ErrNotExist` when the `git` binary is missing. `cmd.Wait()` never does. The check was unreachable dead code. Replaced with proper context-cancellation suppression.

## Test plan
- [ ] `go test ./pkg/git/...` passes
- [ ] Push to a repo while disconnecting mid-transfer → no zombie git processes accumulate
- [ ] Stderr errors from git operations are now logged correctly

Fixes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)