### PR TITLE
feat(backend): set gitweb.owner in git config on repo creation

### DIFF
--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -65,10 +65,23 @@ func (d *Backend) CreateRepository(ctx context.Context, name string, user proto.
 			return err
 		}
 
-		_, err := git.Init(rp, true)
+		rr, err := git.Init(rp, true)
 		if err != nil {
 			d.logger.Debug("failed to create repository", "err", err)
 			return err
+		}
+
+		if user != nil && user.Username() != "" {
+			rcfg, err := rr.Config()
+			if err != nil {
+				d.logger.Error("failed to get repository config", "repo", name, "err", err)
+				return err
+			}
+			rcfg.Section("gitweb").SetOption("owner", user.Username())
+			if err := rr.SetConfig(rcfg); err != nil {
+				d.logger.Error("failed to set gitweb.owner", "repo", name, "err", err)
+				return err
+			}
 		}
 
 		if err := os.WriteFile(filepath.Join(rp, "description"), []byte(opts.Description), fs.ModePerm); err != nil {

--- a/testscript/testdata/gitweb-owner.txtar
+++ b/testscript/testdata/gitweb-owner.txtar
@@ -1,0 +1,25 @@
+# vi: set ft=conf
+
+# Regression test for https://github.com/charmbracelet/soft-serve/issues/753
+# gitweb.owner should be set in the git config when a repo is created.
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# create user1 (non-admin)
+soft user create user1 --key "$USER1_AUTHORIZED_KEY"
+
+# TEST 1: admin creates a repo — gitweb.owner should be "admin"
+soft repo create adminrepo
+readfile $DATA_PATH/repos/adminrepo.git/config
+stdout 'owner = admin'
+
+# TEST 2: user1 creates a repo — gitweb.owner should be "user1"
+usoft repo create userrepo
+readfile $DATA_PATH/repos/userrepo.git/config
+stdout 'owner = user1'
+
+# stop the server
+[windows] stopserver


### PR DESCRIPTION
## Summary

Set the `gitweb.owner` field in the repository's git config when a repository is created via `CreateRepository`. This enables tools like cgit and gitweb that read this field to display the correct owner.

```ini
[gitweb]
	owner = alice
```

- When `user` is `nil` or has an empty username (anonymous/system-created repos), `gitweb.owner` is not set, preserving existing behavior.
- Adds a testscript regression test.

## Test plan
- [ ] `go test ./testscript/...` passes (gitweb-owner.txtar)
- [ ] Create a repo as admin → `git config --local --get gitweb.owner` returns `admin`
- [ ] Create a repo as non-admin user → returns that user's username
- [ ] System operations that create repos (e.g. mirror import) → `gitweb.owner` not set (user is nil)

Fixes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)