### PR TITLE
feat(config): support anon_access and allow_keyless in config file

### DIFF
--- a/cmd/soft/serve/serve.go
+++ b/cmd/soft/serve/serve.go
@@ -12,7 +12,9 @@ import (
 	"syscall"
 	"time"
 
+	"charm.land/log/v2"
 	"github.com/charmbracelet/soft-serve/cmd"
+	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/backend"
 	"github.com/charmbracelet/soft-serve/pkg/config"
 	"github.com/charmbracelet/soft-serve/pkg/db"
@@ -68,6 +70,26 @@ var (
 			db := db.FromContext(ctx)
 			if err := migrate.Migrate(ctx, db); err != nil {
 				return fmt.Errorf("migration error: %w", err)
+			}
+
+			// Apply config-driven settings so operators can automate
+			// server setup without a post-start SSH session.
+			{
+				cfgCtx := config.FromContext(ctx)
+				be := backend.FromContext(ctx)
+				logger := log.FromContext(ctx).WithPrefix("server")
+				if cfgCtx.AnonAccess != "" {
+					if err := be.SetAnonAccess(ctx, access.ParseAccessLevel(cfgCtx.AnonAccess)); err != nil {
+						return fmt.Errorf("set anon_access: %w", err)
+					}
+					logger.Debug("applied anon_access from config", "level", cfgCtx.AnonAccess)
+				}
+				if cfgCtx.AllowKeyless != nil {
+					if err := be.SetAllowKeyless(ctx, *cfgCtx.AllowKeyless); err != nil {
+						return fmt.Errorf("set allow_keyless: %w", err)
+					}
+					logger.Debug("applied allow_keyless from config", "value", *cfgCtx.AllowKeyless)
+				}
 			}
 
 			s, err := NewServer(ctx)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/sshutils"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
@@ -171,6 +172,16 @@ type Config struct {
 	// InitialAdminKeys is a list of public keys that will be added to the list of admins.
 	InitialAdminKeys []string `env:"INITIAL_ADMIN_KEYS" envSeparator:"\n" yaml:"initial_admin_keys"`
 
+	// AnonAccess is the anonymous access level applied on startup.
+	// Valid values: "no-access", "read-only", "read-write", "admin-access".
+	// Leave empty to keep the value stored in the database.
+	AnonAccess string `env:"ANON_ACCESS" yaml:"anon_access"`
+
+	// AllowKeyless controls whether keyless (keyboard-interactive) access is
+	// allowed. When set, this overrides the value stored in the database on
+	// every startup.  Leave unset to keep the database value.
+	AllowKeyless *bool `env:"ALLOW_KEYLESS" yaml:"allow_keyless"`
+
 	// DataPath is the path to the directory where Soft Serve will store its data.
 	DataPath string `env:"DATA_PATH" yaml:"-"`
 }
@@ -190,6 +201,7 @@ func (c *Config) Environ() []string {
 		fmt.Sprintf("SOFT_SERVE_DATA_PATH=%s", c.DataPath),
 		fmt.Sprintf("SOFT_SERVE_NAME=%s", c.Name),
 		fmt.Sprintf("SOFT_SERVE_INITIAL_ADMIN_KEYS=%s", strings.Join(c.InitialAdminKeys, "\n")),
+		fmt.Sprintf("SOFT_SERVE_ANON_ACCESS=%s", c.AnonAccess),
 		fmt.Sprintf("SOFT_SERVE_SSH_ENABLED=%t", c.SSH.Enabled),
 		fmt.Sprintf("SOFT_SERVE_SSH_LISTEN_ADDR=%s", c.SSH.ListenAddr),
 		fmt.Sprintf("SOFT_SERVE_SSH_PUBLIC_URL=%s", c.SSH.PublicURL),
@@ -442,6 +454,21 @@ func (c *Config) Validate() error {
 	}
 
 	c.InitialAdminKeys = pks
+
+	if c.AnonAccess != "" {
+		level := access.ParseAccessLevel(c.AnonAccess)
+		// ParseAccessLevel returns NoAccess for unknown strings, but "no-access"
+		// is also a valid explicit value, so check by re-serialising.
+		if level.String() != c.AnonAccess {
+			return fmt.Errorf("invalid anon_access %q: must be one of %s, %s, %s, %s",
+				c.AnonAccess,
+				access.NoAccess.String(),
+				access.ReadOnlyAccess.String(),
+				access.ReadWriteAccess.String(),
+				access.AdminAccess.String(),
+			)
+		}
+	}
 
 	c.HTTP.CORS.AllowedOrigins = append([]string{c.HTTP.PublicURL}, c.HTTP.CORS.AllowedOrigins...)
 

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -147,6 +147,17 @@ jobs:
 # Additional admin keys.
 #initial_admin_keys:
 #  - "ssh-rsa AAAAB3NzaC1yc2..."
+
+# Anonymous access level applied on every startup.
+# Overrides the value stored in the database when set.
+# Valid values: no-access, read-only, read-write, admin-access.
+# Leave commented out to preserve the database value.
+#anon_access: read-only
+
+# Whether keyless (keyboard-interactive) access is allowed.
+# Overrides the value stored in the database when set.
+# Leave commented out to preserve the database value.
+#allow_keyless: true
 `))
 
 func newConfigFile(cfg *Config) string {

--- a/testscript/testdata/config-initial-settings.txtar
+++ b/testscript/testdata/config-initial-settings.txtar
@@ -1,0 +1,37 @@
+# vi: set ft=conf
+
+# Test that anon_access and allow_keyless set via environment variables are
+# applied to the database on startup, overriding the migration defaults
+# (read-only-access / true).
+
+env SOFT_SERVE_ANON_ACCESS=no-access
+env SOFT_SERVE_ALLOW_KEYLESS=false
+
+exec soft serve &
+ensureserverrunning SSH_PORT
+
+# Admin can still connect
+soft info
+
+# Settings reflect what was configured, not the migration defaults
+soft settings allow-keyless
+stdout 'false'
+
+soft settings anon-access
+stdout 'no-access'
+
+# Repo created by admin is not accessible to unregistered users under no-access
+soft repo create pub1
+! ugit clone ssh://localhost:$SSH_PORT/pub1 upub1
+stderr 'not authorized|unauthorized'
+
+# Unregistered user cannot create repos either
+! usoft repo create blocked
+stderr 'unauthorized'
+
+# Change anon-access to read-only via admin and verify access is restored
+soft settings anon-access read-only
+ugit clone ssh://localhost:$SSH_PORT/pub1 upub1
+
+# stop the server
+[windows] stopserver


### PR DESCRIPTION
## Summary

Add two optional config fields that override the database-backed settings on every startup. This lets operators configure initial access control via config file or environment variables, without needing a post-start SSH admin session — useful for automated deployments and container images.

```yaml
# config.yaml

# Optional: override anon_access on every startup.
# Valid: no-access, read-only, read-write, admin-access
# Leave commented to preserve the DB value.
#anon_access: read-only

# Optional: override allow_keyless on every startup.
# Leave commented to preserve the DB value.
#allow_keyless: true
```

Or via environment variables:
```
SOFT_SERVE_ANON_ACCESS=no-access
SOFT_SERVE_ALLOW_KEYLESS=false
```

## Details

- Both fields are optional with no default — existing behaviour is preserved when they are unset
- `anon_access` is validated against the four known `AccessLevel` strings in `Config.Validate()` — invalid values are rejected at startup with a clear error message
- `allow_keyless` is `*bool` so unset (`nil`) means "don't override"
- Applied in `serve.go` after migrations complete, on every startup
- Config template updated with commented-out examples and doc comments

## Test plan
- [ ] `go test ./pkg/config/...` passes
- [ ] `go test ./testscript/...` passes (config-initial-settings.txtar)
- [ ] Start server with `SOFT_SERVE_ANON_ACCESS=no-access` → `soft settings anon-access` returns `no-access`
- [ ] Start server without the env → DB value unchanged
- [ ] Invalid `anon_access` value → startup error with helpful message

Fixes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)