### PR TITLE
fix(lfs): serialize expires_in as seconds not nanoseconds

### DIFF
--- a/pkg/git/lfs_auth.go
+++ b/pkg/git/lfs_auth.go
@@ -54,7 +54,7 @@ func LFSAuthenticate(ctx context.Context, cmd ServiceCommand) error {
 	expiresAt := now.Add(expiresIn)
 	claims := jwt.RegisteredClaims{
 		Subject:   fmt.Sprintf("%s#%d", user.Username(), user.ID()),
-		ExpiresAt: jwt.NewNumericDate(expiresAt), // expire in an hour
+		ExpiresAt: jwt.NewNumericDate(expiresAt),
 		NotBefore: jwt.NewNumericDate(now),
 		IssuedAt:  jwt.NewNumericDate(now),
 		Issuer:    cfg.HTTP.PublicURL,
@@ -80,6 +80,6 @@ func LFSAuthenticate(ctx context.Context, cmd ServiceCommand) error {
 		},
 		Href:      href,
 		ExpiresAt: expiresAt,
-		ExpiresIn: expiresIn,
+		ExpiresIn: int64(expiresIn / time.Second),
 	})
 }

--- a/pkg/lfs/common.go
+++ b/pkg/lfs/common.go
@@ -68,7 +68,12 @@ type Link struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header,omitempty"`
 	ExpiresAt *time.Time        `json:"expires_at,omitempty"`
-	ExpiresIn *time.Duration    `json:"expires_in,omitempty"`
+	// ExpiresIn is the number of seconds (not nanoseconds, not milliseconds)
+	// until the link expires, per the git-lfs batch API spec. Callers MUST
+	// pass whole seconds (e.g. int64(d / time.Second)). Using int64 instead
+	// of time.Duration avoids serialising nanoseconds, which overflows int32
+	// on 32-bit platforms.
+	ExpiresIn *int64 `json:"expires_in,omitempty"`
 }
 
 // ObjectError defines the JSON structure returned to the client in case of an error.
@@ -94,10 +99,14 @@ type Reference struct {
 }
 
 // AuthenticateResponse is the git-lfs-authenticate JSON response object.
+// ExpiresIn is encoded as seconds per the git-lfs SSH authentication spec:
+// https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md
+// Using int64 (not time.Duration) avoids serialising nanoseconds, which
+// overflows int32 on 32-bit platforms (issue #781).
 type AuthenticateResponse struct {
 	Header    map[string]string `json:"header"`
 	Href      string            `json:"href"`
-	ExpiresIn time.Duration     `json:"expires_in"`
+	ExpiresIn int64             `json:"expires_in"`
 	ExpiresAt time.Time         `json:"expires_at"`
 }
 


### PR DESCRIPTION
## Summary

The git-lfs batch API and SSH authentication protocol require `expires_in` to be the number of **whole seconds** until expiry. The previous type `time.Duration` serialises as **nanoseconds** (Go's native unit), which:

1. **Wrong value sent to clients** — git-lfs clients interpret the value as seconds, so a 1-hour token would appear to expire in ~3,600,000,000,000 seconds (~114,000 years), or worse be rejected as negative.
2. **Overflows int32 on 32-bit platforms** — A 1-hour duration is 3,600,000,000,000 nanoseconds, which exceeds the int32 maximum (~2.1 billion) and wraps to a negative or truncated value when JSON-encoded on i686 and similar architectures. This is the root cause of test failures on i686 (#781).

### Fix

Change `ExpiresIn` in `lfs.Link` and `lfs.AuthenticateResponse` from `*time.Duration` to `*int64` (seconds). `LFSAuthenticate` now converts: `int64(expiresIn / time.Second)`.

## Test plan
- [ ] `go build ./...` passes on amd64 and arm64
- [ ] LFS push/fetch: `git lfs push` authenticates and objects transfer correctly
- [ ] `expires_in` in the JSON response is a reasonable seconds value (e.g. 3600 for 1-hour tokens), not nanoseconds

Fixes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)