### PR TITLE
feat(ui): copy clone command from repo view, fix copy feedback reset

### DIFF
--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -115,8 +115,11 @@ func (r *Repo) commonHelp() []key.Binding {
 	back.SetHelp("esc", "back to menu")
 	tab := r.common.KeyMap.Section
 	tab.SetHelp("tab", "switch tab")
+	copyKey := r.common.KeyMap.Copy
+	copyKey.SetHelp("c", "copy clone cmd")
 	b = append(b, back)
 	b = append(b, tab)
+	b = append(b, copyKey)
 	return b
 }
 
@@ -204,6 +207,15 @@ func (r *Repo) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 			switch {
 			case key.Matches(msg, r.common.KeyMap.Back):
 				cmds = append(cmds, goBackCmd)
+			case key.Matches(msg, r.common.KeyMap.Copy):
+				// Only handle clone copy on the Readme tab to avoid
+				// conflicting with pane-level copy handlers (Files, Log, Refs, Stash).
+				if r.selectedRepo != nil && r.panes[r.activeTab].TabName() == "Readme" {
+					cmd := r.common.CloneCmd(r.common.Config().SSH.PublicURL, r.selectedRepo.Name())
+					if cmd != "" {
+						cmds = append(cmds, copyCmd(cmd, "Clone command copied to clipboard"))
+					}
+				}
 			}
 		}
 	case CopyMsg:

--- a/pkg/ui/pages/selection/item.go
+++ b/pkg/ui/pages/selection/item.go
@@ -18,6 +18,9 @@ import (
 
 var _ sort.Interface = Items{}
 
+// copiedResetMsg is sent after the copy feedback timer expires.
+type copiedResetMsg struct{ gen int }
+
 // Items is a list of Item.
 type Items []Item
 
@@ -98,9 +101,11 @@ func (i Item) Command() string {
 
 // ItemDelegate is the delegate for the item.
 type ItemDelegate struct {
-	common     *common.Common
-	activePane *pane
-	copiedIdx  int
+	common      *common.Common
+	activePane  *pane
+	copiedItem  Item
+	hasCopied   bool
+	copiedGen   int
 }
 
 // NewItemDelegate creates a new ItemDelegate.
@@ -108,7 +113,6 @@ func NewItemDelegate(common *common.Common, activePane *pane) *ItemDelegate {
 	return &ItemDelegate{
 		common:     common,
 		activePane: activePane,
-		copiedIdx:  -1,
 	}
 }
 
@@ -129,7 +133,6 @@ func (d *ItemDelegate) Spacing() int { return 1 }
 
 // Update implements list.ItemDelegate.
 func (d *ItemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd {
-	idx := m.Index()
 	item, ok := m.SelectedItem().(Item)
 	if !ok {
 		return nil
@@ -138,11 +141,22 @@ func (d *ItemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, d.common.KeyMap.Copy):
-			d.copiedIdx = idx
+			d.copiedItem = item
+			d.hasCopied = true
+			d.copiedGen++
+			gen := d.copiedGen
 			return tea.Batch(
 				tea.SetClipboard(item.Command()),
-				m.SetItem(idx, item),
+				func() tea.Msg {
+					time.Sleep(1500 * time.Millisecond)
+					return copiedResetMsg{gen: gen}
+				},
 			)
+		}
+	case copiedResetMsg:
+		if msg.gen == d.copiedGen {
+			d.hasCopied = false
+			d.copiedItem = Item{}
 		}
 	}
 	return nil
@@ -207,10 +221,9 @@ func (d *ItemDelegate) Render(w io.Writer, m list.Model, index int, listItem lis
 
 	cmd := i.Command()
 	cmdStyler := styles.Command.Render
-	if d.copiedIdx == index {
+	if d.hasCopied && d.copiedItem.ID() == i.ID() {
 		cmd = "(copied to clipboard)"
 		cmdStyler = styles.Desc.Render
-		d.copiedIdx = -1
 	}
 	cmd = common.TruncateString(cmd, m.Width()-styles.Base.GetHorizontalFrameSize())
 	s.WriteString(cmdStyler(cmd))


### PR DESCRIPTION
Closes #769

## Summary

- Adds `c` key binding to `Repo.commonHelp()` so it appears in the help footer while browsing a repository, making the feature discoverable.
- Handles `KeyMap.Copy` in `Repo.Update` **on the Readme tab only** to avoid shadowing the pane-level copy handlers used by Files, Log, Refs, and Stash tabs.
- Refactors `ItemDelegate` copy feedback in the repository selector: replaces the `copiedIdx` sentinel (which reset inside `Render`, causing the feedback to flash for only one frame) with `copiedItem`/`hasCopied`/`copiedGen` fields and a timer-based `copiedResetMsg`. The label now shows reliably for 1.5 s before clearing, even when the list is re-rendered mid-timer.

## Test plan

- [ ] In the repo selector (`ssh <host>`) press `c` on a repo — "copied to clipboard" label appears for ~1.5 s then disappears; clipboard contains the clone command.
- [ ] Navigate into a repo, switch to the **Readme** tab, press `c` — status bar shows "Clone command copied to clipboard"; clipboard contains the clone command.
- [ ] On the **Files**, **Log**, **Refs**, or **Stash** tab, press `c` — the pane's own copy handler fires (file path, commit hash, etc.); no clone command is copied.
- [ ] Press `c` in the repo selector, immediately switch repos — the label does not appear on the new selection (generation counter prevents stale reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)