### PR TITLE
fix(ssh): user create -k handles SSH-split public keys

### DIFF
--- a/pkg/ssh/cmd/user.go
+++ b/pkg/ssh/cmd/user.go
@@ -22,15 +22,28 @@ func UserCommand() *cobra.Command {
 	var admin bool
 	var key string
 	userCreateCommand := &cobra.Command{
-		Use:               "create USERNAME",
+		Use:               "create USERNAME [AUTHORIZED_KEY]",
 		Short:             "Create a new user",
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.MinimumNArgs(1),
 		PersistentPreRunE: checkIfAdmin,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var pubkeys []ssh.PublicKey
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
 			username := args[0]
+			// SSH clients strip shell quotes before sending the command, so an
+			// "ssh-ed25519 BASE64" key passed via -k may arrive split across the
+			// flag value and extra positional args. Join them back together.
+			// Extra positional args with no -k flag also provide the key directly
+			// (mirrors the behaviour of `user add-pubkey`).
+			if len(args) > 1 {
+				extra := strings.Join(args[1:], " ")
+				if key == "" {
+					key = extra
+				} else {
+					key = key + " " + extra
+				}
+			}
 			if key != "" {
 				pk, _, err := sshutils.ParseAuthorizedKey(key)
 				if err != nil {


### PR DESCRIPTION
Closes #750

## Root cause

SSH clients strip shell quoting before transmitting the remote command. A key like `ssh-ed25519 BASE64KEY` arrives at the server as two separate tokens. Cobra binds `ssh-ed25519` to the `-k` flag and leaves `BASE64KEY` as a second positional argument, producing:

```
Error: accepts 1 arg(s), received 2
```

## Fix

Change `Args` from `cobra.ExactArgs(1)` to `cobra.MinimumNArgs(1)`. When extra positional args are present, join them (with a space) onto the end of the `-k` flag value so the full key string reaches `ParseAuthorizedKey`.

This mirrors the existing behaviour of `user add-pubkey`, which already uses `cobra.MinimumNArgs(2)` and `strings.Join(args[1:], " ")`.

As a useful side-effect, the public key may now also be supplied as bare positional arguments without `-k`:

```
ssh git.example.com user create alice ssh-ed25519 AAAA...
```

## Test plan

- [ ] `ssh host user create alice -k 'ssh-ed25519 KEY'` — creates user with key (quoting respected when client preserves it)
- [ ] `ssh host user create alice -k ssh-ed25519 KEY` (as SSH sends it, two tokens) — creates user with key correctly
- [ ] `ssh host user create alice ssh-ed25519 KEY` (key as positional args, no flag) — creates user with key correctly
- [ ] `ssh host user create alice` — creates user with no key (unchanged behaviour)
- [ ] `ssh host user create alice -k invalid` — returns parse error (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)