### PR TITLE
fix(ssh): downgrade signal-killed log to debug on client disconnect

### DIFF
--- a/pkg/ssh/cmd/git.go
+++ b/pkg/ssh/cmd/git.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -246,7 +247,11 @@ func gitRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if err := service.Handler(ctx, scmd); err != nil {
-			logger.Error("failed to handle git service", "service", service, "err", err, "repo", name)
+			if ctx.Err() == context.Canceled {
+				logger.Debug("git: client disconnected", "service", service, "err", err, "repo", name)
+			} else {
+				logger.Error("failed to handle git service", "service", service, "err", err, "repo", name)
+			}
 			defer func() {
 				if repo == nil {
 					// If the repo was created, but the request failed, delete it.
@@ -291,7 +296,11 @@ func gitRunE(cmd *cobra.Command, args []string) error {
 		if errors.Is(err, git.ErrInvalidRepo) {
 			return git.ErrInvalidRepo
 		} else if err != nil {
-			logger.Error("failed to handle git service", "service", service, "err", err, "repo", name)
+			if ctx.Err() == context.Canceled {
+				logger.Debug("git: client disconnected", "service", service, "err", err, "repo", name)
+			} else {
+				logger.Error("failed to handle git service", "service", service, "err", err, "repo", name)
+			}
 			return git.ErrSystemMalfunction
 		}
 
@@ -334,7 +343,11 @@ func gitRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if err := service.Handler(ctx, scmd); err != nil {
-			logger.Error("failed to handle lfs service", "service", service, "err", err, "repo", name)
+			if ctx.Err() == context.Canceled {
+				logger.Debug("git: client disconnected", "service", service, "err", err, "repo", name)
+			} else {
+				logger.Error("failed to handle lfs service", "service", service, "err", err, "repo", name)
+			}
 			return git.ErrSystemMalfunction
 		}
 


### PR DESCRIPTION
Closes #807

## Root cause

When a git client (e.g. Flux Source Controller) disconnects after receiving ref advertisements — expected, valid behavior — Go's `exec.CommandContext` kills the git subprocess with SIGKILL. The resulting `"signal: killed"` error was logged unconditionally at `ERROR` level, flooding operator dashboards with false alarms.

## Fix

Check `ctx.Err() == context.Canceled` at each error-logging site in the git command handlers. When the context is cancelled the kill was triggered by client disconnect; log at `DEBUG` with `"git: client disconnected"` and the original error. Genuine server-side failures (context still alive) continue to log at `ERROR`.

Using `== context.Canceled` (not `!= nil`) ensures `context.DeadlineExceeded` (server-side timeout) still logs at `ERROR` — that's an operator-visible signal.

## Test plan

- [ ] Normal git push/clone — no change in behavior
- [ ] Flux or any client that disconnects after `info/refs` — no ERROR log, DEBUG log emitted instead
- [ ] Server-side context deadline exceeded (configured `IdleTimeout`) — still logged at ERROR

🤖 Generated with [Claude Code](https://claude.com/claude-code)