### PR TITLE
fix(mirror): disable gc.auto and remove timeout to prevent CPU peg on large repos

### DIFF
--- a/pkg/jobs/mirror.go
+++ b/pkg/jobs/mirror.go
@@ -69,9 +69,13 @@ func (m mirrorPull) Func(ctx context.Context) func() {
 						"remote update --prune", // update remote and prune remote refs
 					}
 
+					gitSyncFailed := false
 					for _, c := range cmds {
-						args := strings.Split(c, " ")
-						cmd := git.NewCommand(args...).WithContext(ctx)
+						// Prepend -c gc.auto=0 to disable automatic GC which
+						// would otherwise spawn git rev-list --objects --all
+						// and peg a CPU for the entire mirror-sync window.
+						args := append([]string{"-c", "gc.auto=0"}, strings.Split(c, " ")...)
+						cmd := git.NewCommand(args...).WithContext(ctx).WithTimeout(-1)
 						cmd.AddEnvs(
 							fmt.Sprintf(`GIT_SSH_COMMAND=ssh -o UserKnownHostsFile="%s" -o StrictHostKeyChecking=no -i "%s"`,
 								filepath.Join(cfg.DataPath, "ssh", "known_hosts"),
@@ -80,8 +84,14 @@ func (m mirrorPull) Func(ctx context.Context) func() {
 						)
 
 						if _, err := cmd.RunInDir(r.Path); err != nil {
-							logger.Error("error running git remote update", "repo", name, "err", err)
+							logger.Error("error running git mirror sync", "repo", name, "cmd", c, "err", err)
+							gitSyncFailed = true
+							break
 						}
+					}
+
+					if gitSyncFailed {
+						return
 					}
 
 					if cfg.LFS.Enabled {


### PR DESCRIPTION
Closes #777

## Root cause

`git fetch --prune` and `git remote update --prune` both trigger `gc --auto` by default. On large repos (e.g. NixOS/nixpkgs) this spawns `git rev-list --objects --all` which pegs a CPU for the entire mirror-sync window.

Additionally, the default 1-minute timeout was killing sync jobs for large repos before they could complete.

## Fix

1. **Disable auto-GC** — prepend `-c gc.auto=0` to all git commands in the mirror sync loop, preventing the expensive GC pass from running during mirror syncs.
2. **Remove timeout** — use `.WithTimeout(-1)` so large-repo syncs are not killed by the default 1-minute limit. This matches the existing behavior in `ImportRepository` for the initial clone.
3. **Break on first error** — stop the command loop when `git fetch --prune` fails instead of continuing to `git remote update`, which would operate on stale refs.
4. **Skip LFS sync on failure** — return early before LFS sync when git sync fails to avoid pulling wrong objects against stale refs.

## Test plan

- [ ] Mirror a large repo (e.g. NixOS/nixpkgs) — CPU stays reasonable during sync
- [ ] Mirror a normal repo — sync completes correctly
- [ ] Simulate a failing git fetch — LFS sync is skipped
- [ ] Error log shows the failing command name

🤖 Generated with [Claude Code](https://claude.com/claude-code)