### PR TITLE
fix(web): return io.ErrShortWrite and handle EOF-with-data in ReadFrom

### DIFF
--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -464,21 +464,26 @@ func (f *flushResponseWriter) ReadFrom(r io.Reader) (int64, error) {
 	var n int64
 	p := make([]byte, 1024)
 	for {
-		nRead, err := r.Read(p)
-		if err == io.EOF {
+		nRead, readErr := r.Read(p)
+		if nRead > 0 {
+			nWrite, err := f.ResponseWriter.Write(p[:nRead])
+			if err != nil {
+				return n, err
+			}
+			if nWrite < nRead {
+				return n, io.ErrShortWrite
+			}
+			n += int64(nWrite)
+			// ResponseWriter must support http.Flusher to handle buffered output.
+			if err := flusher.Flush(); err != nil {
+				return n, fmt.Errorf("%w: error while flush", err)
+			}
+		}
+		if readErr == io.EOF {
 			break
 		}
-		nWrite, err := f.ResponseWriter.Write(p[:nRead])
-		if err != nil {
-			return n, err
-		}
-		if nRead != nWrite {
-			return n, err
-		}
-		n += int64(nRead)
-		// ResponseWriter must support http.Flusher to handle buffered output.
-		if err := flusher.Flush(); err != nil {
-			return n, fmt.Errorf("%w: error while flush", err)
+		if readErr != nil {
+			return n, readErr
 		}
 	}
 


### PR DESCRIPTION
Closes #616

## Bugs fixed

Two bugs in `flushResponseWriter.ReadFrom`:

**1. Short write returned nil error**

When `nRead != nWrite` (the write was short), the code returned `err` which was `nil` at that point — the `Write` succeeded partially but returned no error. Fix: return `io.ErrShortWrite` to match the `io.Copy` contract.

**2. EOF-with-data dropped the last chunk**

The loop broke on `io.EOF` before writing the bytes returned in the same `Read` call. The `io.Reader` contract explicitly allows returning `n > 0` alongside `io.EOF`. Breaking before the write silently dropped the last chunk of data.

Fix: write `p[:nRead]` whenever `nRead > 0`, then check `readErr == io.EOF` to break.

**3. Byte counter now uses nWrite**

`n` accumulates `nWrite` (bytes actually written to the response) rather than `nRead`, so the caller sees the correct number of bytes transferred.

## Test plan

- [ ] Normal git clone/fetch — unchanged behavior
- [ ] Response where the last `Read` returns data + EOF simultaneously — data is not dropped
- [ ] Short write scenario — `io.ErrShortWrite` returned instead of nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)