### PR TITLE
fix(ssh): create host key directory before generating key

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -82,6 +83,13 @@ func NewSSHServer(ctx context.Context) (*SSHServer, error) {
 			// This must come first to set up the context.
 			ContextMiddleware(cfg, dbx, datastore, be, logger),
 		),
+	}
+
+	// Ensure the directory for the host key file exists.
+	if dir := filepath.Dir(cfg.SSH.KeyPath); dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("create ssh key dir: %w", err)
+		}
 	}
 
 	opts := []ssh.Option{


### PR DESCRIPTION
Closes #779

## Root cause

When `ssh.key_path` is set to a path whose parent directory does not yet exist, `keygen.New` inside `wish.WithHostKeyPath` fails to write the key file. `wish` then falls back to generating a new ephemeral in-memory host key — one that is not persisted — causing the server's SSH identity to change on every restart and triggering `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED` errors for clients.

## Fix

Call `os.MkdirAll` on the key file's parent directory before building the SSH server options. This mirrors the implicit assumption that `$DATA_PATH/ssh/` exists for the default `KeyPath`, and makes any custom `key_path` work correctly on first start.

The `dir != "."` guard prevents a no-op `MkdirAll(".")` when `KeyPath` is a bare filename with no directory component.

## Test plan

- [ ] Set `ssh.key_path: /custom/path/to/ssh_key` where `/custom/path/to/` does not exist — server starts and creates the directory
- [ ] Restart server — SSH identity unchanged, no `REMOTE HOST IDENTIFICATION HAS CHANGED`
- [ ] Default config (`$DATA_PATH/ssh/` already exists) — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)