### PR TITLE
docs: fix typo in inline diff comment

### DIFF
--- a/git/patch.go
+++ b/git/patch.go
@@ -63,7 +63,7 @@ func (s *DiffSection) diffFor(line *git.DiffLine) string {
 func diffsToString(diffs []diffmatchpatch.Diff, lineType git.DiffLineType) string {
 	buf := bytes.NewBuffer(nil)
 
-	// Reproduce signs which are cutted for inline diff before.
+	// Reproduce signs that were cut off for inline diff before.
 	switch lineType {
 	case git.DiffLineAdd:
 		buf.WriteByte('+')


### PR DESCRIPTION
## Summary

Fix a typo in the inline diff comment in `git/patch.go`.

## Related issue

N/A. This is a trivial comment-only fix.

## Guideline alignment

No `CONTRIBUTING.md` or pull request template was present in the repository root or `.github` directory when this PR was prepared.

## Validation/testing

Not run. This is a comment-only change.
