### PR TITLE
add support for docker container to run as any uid/gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ EXPOSE 23233/tcp
 EXPOSE 9418/tcp
 
 # Set the default command
-ENTRYPOINT [ "/usr/local/bin/soft", "serve" ]
+ENTRYPOINT [ "/entrypoint.sh", "/usr/local/bin/soft", "serve" ]
 
-RUN apk update && apk add --update git bash openssh && rm -rf /var/cache/apk/*
+RUN apk update && apk add --update git bash openssh su-exec && rm -rf /var/cache/apk/*
 
+COPY entrypoint.sh /entrypoint.sh
 COPY soft /usr/local/bin/soft

--- a/docker.md
+++ b/docker.md
@@ -19,6 +19,8 @@ docker run \
   --publish 23233:23233 \
   --publish 9418:9418 \
   -e SOFT_SERVE_INITIAL_ADMIN_KEYS="YOUR_ADMIN_KEY_HERE" \
+  -e PUID=1000 \
+  -e PGID=1000 \
   --restart unless-stopped \
   charmcli/soft-serve:latest
 ```
@@ -41,6 +43,8 @@ services:
       - 9418:9418
     environment:
       SOFT_SERVE_INITIAL_ADMIN_KEYS: "YOUR_ADMIN_KEY_HERE"
+      PUID: 1000
+      PGID: 1000
     restart: unless-stopped
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+chown -R ${PUID:-1000}:${PGID:-1000} /soft-serve
+exec su-exec "${PUID:-1000}:${PGID:-1000}" "$@"


### PR DESCRIPTION
Adds the option for the docker container to run as any uid/gid.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).