### PR TITLE
fix: use correct error variable in stderr copy check

### DIFF
--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -147,7 +147,7 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, erro := io.Copy(scmd.Stderr, stderr); err != nil {
+			if _, erro := io.Copy(scmd.Stderr, stderr); erro != nil {
 				log.Errorf("gitServiceHandler: failed to copy stderr: %v", erro)
 			}
 		}()

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -147,8 +147,8 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, erro := io.Copy(scmd.Stderr, stderr); erro != nil {
-				log.Errorf("gitServiceHandler: failed to copy stderr: %v", erro)
+			if _, err := io.Copy(scmd.Stderr, stderr); err != nil {
+				log.Errorf("gitServiceHandler: failed to copy stderr: %v", err)
 			}
 		}()
 	}


### PR DESCRIPTION
## Problem

In `gitServiceHandler` (`pkg/git/service.go`), the stderr `io.Copy` goroutine checks the wrong error variable:

```go
if _, erro := io.Copy(scmd.Stderr, stderr); err != nil {  // checks 'err', not 'erro'
    log.Errorf("gitServiceHandler: failed to copy stderr: %v", erro)
}
```

The condition uses `err` (from the outer scope — set by `StdinPipe`/`StdoutPipe`/`StderrPipe` calls) instead of `erro` (the actual error from `io.Copy`).

**Effect:**
- When `err` is nil (normal case): stderr copy errors are **silently swallowed** — the condition is false and the error is never logged.
- When `err` is non-nil (pipe creation failed): the condition is always true, but `erro` is nil so the log message prints `<nil>` instead of the actual error.

## Fix

Change `err != nil` to `erro != nil` on line 150:

```go
if _, erro := io.Copy(scmd.Stderr, stderr); erro != nil {
```

This is a single-character fix that ensures stderr copy failures are properly detected and logged.

## Testing

- `go build ./pkg/git/...` — passes
- `go test ./pkg/git/...` — passes (1.781s)
- `go vet ./pkg/git/...` — clean