### PR TITLE
fix: reap zombie child processes in container environments

### DIFF
--- a/cmd/soft/serve/reap_linux.go
+++ b/cmd/soft/serve/reap_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package serve
+
+import (
+	"context"
+	"time"
+
+	"charm.land/log/v2"
+	"golang.org/x/sys/unix"
+)
+
+// reapZombies periodically reaps zombie child processes.
+//
+// When soft-serve runs as PID 1 in a container, orphaned descendant
+// processes (e.g. grandchild git pack-objects left behind when a git
+// parent exits before waiting for them) are reparented to PID 1.
+// Without an init system these processes become zombies because the
+// Go runtime only tracks children spawned via os/exec, not reparented
+// orphans. This goroutine periodically calls waitpid(-1, WNOHANG) to
+// clean them up.
+func reapZombies(ctx context.Context, logger *log.Logger) {
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				for {
+					var status unix.WaitStatus
+					pid, err := unix.Wait4(-1, &status, unix.WNOHANG, nil)
+					if err != nil || pid <= 0 {
+						break
+					}
+					logger.Debugf("reaped zombie child pid=%d status=%d", pid, status)
+				}
+			}
+		}
+	}()
+}

--- a/cmd/soft/serve/reap_other.go
+++ b/cmd/soft/serve/reap_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package serve
+
+import (
+	"context"
+
+	"charm.land/log/v2"
+)
+
+// reapZombies is a no-op on non-Linux platforms.
+// See reap_linux.go for the Linux implementation.
+func reapZombies(_ context.Context, _ *log.Logger) {}

--- a/cmd/soft/serve/serve.go
+++ b/cmd/soft/serve/serve.go
@@ -75,6 +75,11 @@ var (
 				return fmt.Errorf("start server: %w", err)
 			}
 
+			// Start zombie child reaper for container environments where
+			// soft-serve may run as PID 1 without an init supervisor.
+			// See https://github.com/charmbracelet/soft-serve/issues/891
+			reapZombies(ctx, s.logger)
+
 			if syncHooks {
 				be := backend.FromContext(ctx)
 				if err := cmd.InitializeHooks(ctx, cfg, be); err != nil {


### PR DESCRIPTION
## Problem

When soft-serve runs as PID 1 in a container (e.g. Kubernetes) without an init supervisor like tini, orphaned descendant processes are reparented to PID 1 and become zombies. This happens because:

1. Git operations spawn child processes (e.g. `git pack-objects`, `git index-pack`)
2. When the parent git process exits, its children are reparented to PID 1 (soft-serve)
3. The Go runtime only tracks children spawned via `os/exec`, not reparented orphans
4. Without `waitpid()` calls, these processes accumulate as zombies

In the reporter's Kubernetes environment, this caused **30k+ zombies in under 24 hours**, leading to PID exhaustion and node failure.

## Fix

Add a periodic zombie reaper goroutine that calls `waitpid(-1, WNOHANG)` every 10 seconds to clean up any zombie children. The reaper:

- Runs only on **Linux** (where the PID 1 container issue manifests)
- Is a **no-op** on other platforms (macOS, Windows)
- Uses `golang.org/x/sys/unix.Wait4` (already a dependency)
- Stops cleanly when the server context is canceled
- Logs reaped PIDs at debug level

## Changes

- `cmd/soft/serve/reap_linux.go` — Linux implementation using `unix.Wait4`
- `cmd/soft/serve/reap_other.go` — no-op stub for non-Linux platforms
- `cmd/soft/serve/serve.go` — call `reapZombies()` during server startup

## Testing

```bash
go build ./...    # passes
go test ./cmd/soft/serve/  # passes
```

Fixes #891