### PR TITLE
fix(ui): use path.Join for git tree paths on Windows

### DIFF
--- a/git/repo.go
+++ b/git/repo.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	gopath "path"
 	"path/filepath"
 	"strings"
 
@@ -123,8 +124,9 @@ func (r *Repository) Tree(ref *Reference) (*Tree, error) {
 }
 
 // TreePath returns the tree for the given path.
+// Git paths always use forward slashes regardless of OS.
 func (r *Repository) TreePath(ref *Reference, path string) (*Tree, error) {
-	path = filepath.Clean(path)
+	path = gopath.Clean(filepath.ToSlash(path))
 	if path == "." {
 		path = ""
 	}

--- a/git/repo_test.go
+++ b/git/repo_test.go
@@ -1,0 +1,47 @@
+package git
+
+import (
+	gopath "path"
+	"strings"
+	"testing"
+)
+
+func TestGitPathHelpersUseForwardSlashes(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"join", gopath.Join("dot_config", "bat"), "dot_config/bat"},
+		{"dir", gopath.Dir("dot_config/bat"), "dot_config"},
+		{"clean nested", gopath.Clean("dot_config//bat"), "dot_config/bat"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Fatalf("got %q, want %q", tc.got, tc.want)
+			}
+			if strings.Contains(tc.got, `\`) {
+				t.Fatalf("git paths must use forward slashes, got %q", tc.got)
+			}
+		})
+	}
+}
+
+func TestTreePathCleansGitPaths(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"dot_config/bat", "dot_config/bat"},
+		{"dot_config//bat", "dot_config/bat"},
+		{".", ""},
+		{"", ""},
+	} {
+		got := gopath.Clean(tc.in)
+		if got == "." {
+			got = ""
+		}
+		if got != tc.want {
+			t.Fatalf("clean(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/git/repo_test.go
+++ b/git/repo_test.go
@@ -1,47 +1,94 @@
 package git
 
 import (
-	gopath "path"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestGitPathHelpersUseForwardSlashes(t *testing.T) {
-	cases := []struct {
-		name string
-		got  string
-		want string
-	}{
-		{"join", gopath.Join("dot_config", "bat"), "dot_config/bat"},
-		{"dir", gopath.Dir("dot_config/bat"), "dot_config"},
-		{"clean nested", gopath.Clean("dot_config//bat"), "dot_config/bat"},
+// setupTestRepo creates a temp git repo containing dot_config/bat and returns
+// the opened repository and its HEAD reference.
+func setupTestRepo(t *testing.T) (*Repository, *Reference) {
+	t.Helper()
+	ctx := context.Background()
+
+	repoPath := filepath.Join(t.TempDir(), "test-repo")
+	nestedDir := filepath.Join(repoPath, "dot_config")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "bat"), []byte("test content"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.got != tc.want {
-				t.Fatalf("got %q, want %q", tc.got, tc.want)
-			}
-			if strings.Contains(tc.got, `\`) {
-				t.Fatalf("git paths must use forward slashes, got %q", tc.got)
-			}
-		})
+	for _, args := range [][]string{
+		{"init"},
+		{"add", "."},
+		{"-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "init"},
+	} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = repoPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %v\n%s", args[0], err, out)
+		}
+	}
+
+	repo, err := Open(repoPath)
+	if err != nil {
+		t.Fatalf("failed to open repository: %v", err)
+	}
+	ref, err := repo.HEAD()
+	if err != nil {
+		t.Fatalf("failed to get HEAD: %v", err)
+	}
+	return repo, ref
+}
+
+func TestTreePathForwardSlashes(t *testing.T) {
+	repo, ref := setupTestRepo(t)
+
+	// TreePath should clean the double slash and resolve the directory.
+	tree, err := repo.TreePath(ref, "dot_config//")
+	if err != nil {
+		t.Fatalf("TreePath failed: %v", err)
+	}
+
+	entries, err := tree.Entries()
+	if err != nil {
+		t.Fatalf("failed to get entries: %v", err)
+	}
+
+	for _, e := range entries {
+		path := e.File().Path()
+		if strings.Contains(path, `\`) {
+			t.Errorf("entry path contains backslash: %q", path)
+		}
 	}
 }
 
-func TestTreePathCleansGitPaths(t *testing.T) {
-	for _, tc := range []struct{ in, want string }{
-		{"dot_config/bat", "dot_config/bat"},
-		{"dot_config//bat", "dot_config/bat"},
-		{".", ""},
-		{"", ""},
-	} {
-		got := gopath.Clean(tc.in)
-		if got == "." {
-			got = ""
+func TestTreeEntryPathForwardSlashes(t *testing.T) {
+	repo, ref := setupTestRepo(t)
+
+	tree, err := repo.TreePath(ref, "dot_config")
+	if err != nil {
+		t.Fatalf("TreePath failed: %v", err)
+	}
+
+	entries, err := tree.Entries()
+	if err != nil {
+		t.Fatalf("failed to get entries: %v", err)
+	}
+
+	for _, e := range entries {
+		path := e.File().Path()
+		if strings.Contains(path, `\`) {
+			t.Errorf("entry path contains backslash: %q", path)
 		}
-		if got != tc.want {
-			t.Fatalf("clean(%q) = %q, want %q", tc.in, got, tc.want)
+		if !strings.Contains(path, "/") {
+			t.Errorf("expected forward slash in path: %q", path)
 		}
 	}
 }

--- a/git/tree.go
+++ b/git/tree.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"io"
 	"io/fs"
-	"path/filepath"
+	gopath "path"
 	"sort"
 
 	"github.com/aymanbagabas/git-module"
@@ -103,7 +103,7 @@ func (t *Tree) Entries() (Entries, error) {
 	for i, e := range entries {
 		ret[i] = &TreeEntry{
 			TreeEntry: e,
-			path:      filepath.Join(t.Path, e.Name()),
+			path:      gopath.Join(t.Path, e.Name()),
 		}
 	}
 	return ret, nil
@@ -117,7 +117,7 @@ func (t *Tree) TreeEntry(path string) (*TreeEntry, error) {
 	}
 	return &TreeEntry{
 		TreeEntry: entry,
-		path:      filepath.Join(t.Path, entry.Name()),
+		path:      gopath.Join(t.Path, entry.Name()),
 	}, nil
 }
 

--- a/git/utils.go
+++ b/git/utils.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/gobwas/glob"
@@ -10,7 +11,7 @@ import (
 // LatestFile returns the contents of the first file at the specified path pattern in the repository and its file path.
 func LatestFile(repo *Repository, ref *Reference, pattern string) (string, string, error) {
 	g := glob.MustCompile(pattern)
-	dir := filepath.Dir(pattern)
+	dir := path.Dir(pattern)
 	if ref == nil {
 		head, err := repo.HEAD()
 		if err != nil {
@@ -28,7 +29,7 @@ func LatestFile(repo *Repository, ref *Reference, pattern string) (string, strin
 	}
 	for _, e := range ents {
 		te := e
-		fp := filepath.Join(dir, te.Name())
+		fp := path.Join(dir, te.Name())
 		if te.IsTree() {
 			continue
 		}

--- a/pkg/ui/pages/repo/files.go
+++ b/pkg/ui/pages/repo/files.go
@@ -3,7 +3,7 @@ package repo
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -253,7 +253,7 @@ func (f *Files) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 		switch sel := msg.IdentifiableItem.(type) {
 		case FileItem:
 			f.currentItem = &sel
-			f.path = filepath.Join(f.path, sel.entry.Name())
+			f.path = path.Join(f.path, sel.entry.Name())
 			if sel.entry.IsTree() {
 				cmds = append(cmds, f.selectTreeCmd)
 			} else {
@@ -458,19 +458,19 @@ func (f *Files) selectFileCmd() tea.Msg {
 		if !bin {
 			bin, err = fi.IsBinary()
 			if err != nil {
-				f.path = filepath.Dir(f.path)
+				f.path = path.Dir(f.path)
 				return common.ErrorMsg(err)
 			}
 		}
 
 		if bin {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(errBinaryFile)
 		}
 
 		c, err := fi.Bytes()
 		if err != nil {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(err)
 		}
 
@@ -527,7 +527,7 @@ func renderBlame(c common.Common, f *FileItem, b *gitm.Blame) string {
 }
 
 func (f *Files) deselectItemCmd() tea.Cmd {
-	f.path = filepath.Dir(f.path)
+	f.path = path.Dir(f.path)
 	index := 0
 	if len(f.lastSelected) > 0 {
 		index = f.lastSelected[len(f.lastSelected)-1]

--- a/pkg/ui/pages/repo/readme.go
+++ b/pkg/ui/pages/repo/readme.go
@@ -1,7 +1,7 @@
 package repo
 
 import (
-	"path/filepath"
+	"path"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -147,7 +147,7 @@ func (r *Readme) SpinnerID() int {
 
 // StatusBarValue implements statusbar.StatusBar.
 func (r *Readme) StatusBarValue() string {
-	dir := filepath.Dir(r.readmePath)
+	dir := path.Dir(r.readmePath)
 	if dir == "." || dir == "" {
 		return " "
 	}


### PR DESCRIPTION
## Summary

Fix file browser navigation failing on Windows hosts when browsing repository subdirectories. Git always uses forward slashes (`/`) for paths; `filepath.Join`/`Dir`/`Clean` on Windows converts them to backslashes (`\`), which git does not recognize.

## Motivation

Fixes #681 — users on Windows (and clients connecting to Windows-hosted servers) could only navigate one directory level deep in the Files tab. Entering a subdirectory either showed no change or duplicated path segments like `\bat`.

## Changes

- `pkg/ui/pages/repo/files.go` — use `path.Join`/`path.Dir` for browser navigation state
- `pkg/ui/pages/repo/readme.go` — use `path.Dir` for readme path display
- `git/utils.go` — use `path.Join`/`path.Dir` in `LatestFile` pattern matching
- `git/repo.go` — use `path.Clean(filepath.ToSlash(...))` in `TreePath`
- `git/tree.go` — use `path.Join` for `TreeEntry` logical paths
- `git/repo_test.go` — regression tests for forward-slash invariant

OS filesystem paths (data directory, hooks, LFS storage) are unchanged and still correctly use `filepath`.

## Tests

```bash
go test ./git/... -count=1
go test ./... -count=1
```

All tests pass, including `testscript` integration suite (~67s).

## Notes

Related to closed PR #815 (same root cause; redirected to fork workflow). This version also fixes `TreePath` and `git/tree.go` entry path construction, which were not covered in #815.