### PR TITLE
fix(jobs): disable default timeout for mirror sync git commands

### DIFF
--- a/pkg/jobs/mirror.go
+++ b/pkg/jobs/mirror.go
@@ -71,7 +71,7 @@ func (m mirrorPull) Func(ctx context.Context) func() {
 
 					for _, c := range cmds {
 						args := strings.Split(c, " ")
-						cmd := git.NewCommand(args...).WithContext(ctx)
+						cmd := git.NewCommand(args...).WithContext(ctx).WithTimeout(-1)
 						cmd.AddEnvs(
 							fmt.Sprintf(`GIT_SSH_COMMAND=ssh -o UserKnownHostsFile="%s" -o StrictHostKeyChecking=no -i "%s"`,
 								filepath.Join(cfg.DataPath, "ssh", "known_hosts"),


### PR DESCRIPTION
## Summary

Mirror sync jobs now disable git-module's 1-minute default timeout for `fetch --prune` and `remote update --prune`, preventing large mirror repos from being left in a broken partially-synced state.

## Motivation

`mirror-pull` builds git commands without an explicit timeout, so git-module applies `DefaultTimeout` (1 minute). For large repos, the fetch can be killed mid-transfer after `--prune` has already removed local refs that no longer exist on the remote, but before new refs are fully fetched.

`ImportRepository` already uses `Timeout: -1` for the initial mirror clone; the periodic sync path did not.

Fixes #803

## Changes

- Add `.WithTimeout(-1)` to mirror sync git commands in `pkg/jobs/mirror.go`
- Matches the existing pattern used in `git/server.go` and `pkg/lfs/scanner.go`

## Tests

- `go test ./pkg/jobs/... ./git/...` — pass

## Notes

No new unit test added; timeout behavior is inherited from git-module and would be slow/flaky to exercise in CI. The change is a one-line call-site fix consistent with other long-running git operations in this repo.