### PR TITLE
feat: default repo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,24 @@ full privileges.
 Using this environment variable, Soft Serve will create a new `admin` user that
 has full privileges. You can rename and change the user settings later.
 
+If you'd like a repository to exist the moment the server finishes booting,
+with no human logging in to run `repo create`, set `SOFT_SERVE_DEFAULT_REPO`
+to a repository name. This is useful for GitOps tools like ArgoCD that need a
+git remote to point at as part of their own bootstrap (e.g. from a Helm chart
+or Terraform apply):
+
+```sh
+SOFT_SERVE_INITIAL_ADMIN_KEYS="$(cat ~/.ssh/id_ed25519.pub)" \
+SOFT_SERVE_DEFAULT_REPO=gitops \
+  soft serve
+```
+
+The repository is created empty and public, exactly as if a human had run
+`repo create gitops` with no flags; only its *existence* is guaranteed on
+boot, not its reachability, which is still governed entirely by the
+`anon-access`/`allow-keyless` settings described below. Booting again against
+the same data directory is a no-op if the repository already exists.
+
 Check out [Systemd][systemd] on how to run Soft Serve as a service using
 Systemd. Soft Serve packages in our Apt/Yum repositories come with Systemd
 service units.
@@ -269,6 +287,10 @@ stats:
 # server for local dev tooling), not for production use.
 #anon_access: "admin-access"
 #allow_keyless: true
+
+# Repository name to create on boot if it does not already exist.
+# Leave empty to disable.
+#default_repo: ""
 ```
 
 You can also use environment variables, to override these settings. All server
@@ -283,6 +305,7 @@ name all in uppercase. Here are some examples:
 - `SOFT_SERVE_GIT_MAX_CONNECTIONS`: The number of simultaneous connections to git daemon
 - `SOFT_SERVE_ANON_ACCESS`: Overrides the `anon-access` setting (see [Authentication](#authentication))
 - `SOFT_SERVE_ALLOW_KEYLESS`: Overrides the `allow-keyless` setting (see [Authentication](#authentication))
+- `SOFT_SERVE_DEFAULT_REPO`: Repository name to create on boot if missing
 
 #### Database Configuration
 

--- a/cmd/soft/serve/server.go
+++ b/cmd/soft/serve/server.go
@@ -16,8 +16,10 @@ import (
 	"github.com/charmbracelet/soft-serve/pkg/daemon"
 	"github.com/charmbracelet/soft-serve/pkg/db"
 	"github.com/charmbracelet/soft-serve/pkg/jobs"
+	"github.com/charmbracelet/soft-serve/pkg/proto"
 	sshsrv "github.com/charmbracelet/soft-serve/pkg/ssh"
 	"github.com/charmbracelet/soft-serve/pkg/stats"
+	"github.com/charmbracelet/soft-serve/pkg/utils"
 	"github.com/charmbracelet/soft-serve/pkg/web"
 	"github.com/charmbracelet/ssh"
 	"golang.org/x/sync/errgroup"
@@ -69,6 +71,8 @@ func NewServer(ctx context.Context) (*Server, error) {
 	}
 
 	srv.Cron = sched
+
+	ensureDefaultRepo(ctx, cfg, be, logger)
 
 	srv.SSHServer, err = sshsrv.NewSSHServer(ctx)
 	if err != nil {
@@ -123,6 +127,43 @@ func warnIfAnonAdminAccess(ctx context.Context, be *backend.Backend, logger *log
 	logger.Warn("# This is intended for local/dev use only. Do not expose this  #")
 	logger.Warn("# server to an untrusted network.                              #")
 	logger.Warn("################################################################")
+}
+
+// ensureDefaultRepo creates the repo named by cfg.DefaultRepo if it does not
+// already exist. It never fails startup: it logs invalid names and creation
+// errors, then returns.
+func ensureDefaultRepo(ctx context.Context, cfg *config.Config, be *backend.Backend, logger *log.Logger) {
+	if cfg.DefaultRepo == "" {
+		return
+	}
+
+	name := utils.SanitizeRepo(cfg.DefaultRepo)
+	if err := utils.ValidateRepo(name); err != nil {
+		logger.Warn("invalid default_repo, skipping", "name", cfg.DefaultRepo, "err", err)
+		return
+	}
+
+	if _, err := be.Repository(ctx, name); err == nil {
+		return
+	} else if !errors.Is(err, proto.ErrRepoNotFound) {
+		logger.Warn("failed to look up default repo", "name", name, "err", err)
+		return
+	}
+
+	// The migration always inserts a user at ID 1. The repos table requires
+	// a non-null owner, so we attribute the repo to that account.
+	owner, err := be.UserByID(ctx, 1)
+	if err != nil {
+		logger.Warn("failed to look up default repo owner, skipping", "name", name, "err", err)
+		return
+	}
+
+	if _, err := be.CreateRepository(ctx, name, owner, proto.RepositoryOptions{}); err != nil && !errors.Is(err, proto.ErrRepoExist) {
+		logger.Warn("failed to create default repo", "name", name, "err", err)
+		return
+	}
+
+	logger.Info("created default repo", "name", name)
 }
 
 // ReloadCertificates reloads the TLS certificates for the HTTP server.

--- a/cmd/soft/serve/server_test.go
+++ b/cmd/soft/serve/server_test.go
@@ -3,6 +3,9 @@ package serve
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -12,37 +15,42 @@ import (
 	"github.com/charmbracelet/soft-serve/pkg/config"
 	"github.com/charmbracelet/soft-serve/pkg/db"
 	"github.com/charmbracelet/soft-serve/pkg/db/migrate"
+	"github.com/charmbracelet/soft-serve/pkg/proto"
 	"github.com/charmbracelet/soft-serve/pkg/store"
 	"github.com/charmbracelet/soft-serve/pkg/store/database"
 	"github.com/matryer/is"
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // sqlite driver
 )
 
-// newTestBackend returns a Backend backed by a real, freshly migrated
-// SQLite database, along with the *config.Config it was constructed with,
-// so tests can set AnonAccess/AllowKeyless overrides directly.
-func newTestBackend(t *testing.T) (*backend.Backend, *config.Config) {
-	t.Helper()
-	is := is.New(t)
-	ctx := context.Background()
+func setupTestBackend(tb testing.TB) (context.Context, *config.Config, *backend.Backend) {
+	tb.Helper()
+	ctx, cfg, be, _ := setupTestBackendWithDB(tb)
+	return ctx, cfg, be
+}
 
-	dp := t.TempDir()
+func setupTestBackendWithDB(tb testing.TB) (context.Context, *config.Config, *backend.Backend, *db.DB) {
+	tb.Helper()
+	is := is.New(tb)
+
 	cfg := config.DefaultConfig()
-	cfg.DataPath = dp
-	cfg.DB.Driver = "sqlite"
-	cfg.DB.DataSource = dp + "/test.db"
+	cfg.DataPath = tb.TempDir()
+	is.NoErr(cfg.Validate())
 
+	ctx := context.Background()
 	ctx = config.WithContext(ctx, cfg)
+
+	is.NoErr(os.MkdirAll(cfg.DataPath, os.ModePerm))
 	dbx, err := db.Open(ctx, cfg.DB.Driver, cfg.DB.DataSource)
 	is.NoErr(err)
-	t.Cleanup(func() { dbx.Close() }) //nolint:errcheck
+	tb.Cleanup(func() { dbx.Close() }) //nolint: errcheck
 
 	is.NoErr(migrate.Migrate(ctx, dbx))
+
 	dbstore := database.New(ctx, dbx)
 	ctx = store.WithContext(ctx, dbstore)
 	be := backend.New(ctx, cfg, dbx, dbstore)
 
-	return be, cfg
+	return ctx, cfg, be, dbx
 }
 
 func TestWarnIfAnonAdminAccess(t *testing.T) {
@@ -61,8 +69,7 @@ func TestWarnIfAnonAdminAccess(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			is := is.New(t)
-			be, cfg := newTestBackend(t)
-			ctx := context.Background()
+			ctx, cfg, be := setupTestBackend(t)
 
 			allow := c.allowKeyless
 			cfg.AllowKeyless = &allow
@@ -77,4 +84,141 @@ func TestWarnIfAnonAdminAccess(t *testing.T) {
 			is.Equal(gotWarning, c.wantWarning)
 		})
 	}
+}
+
+func TestEnsureDefaultRepoDisabled(t *testing.T) {
+	is := is.New(t)
+	ctx, cfg, be := setupTestBackend(t)
+
+	cfg.DefaultRepo = ""
+	ensureDefaultRepo(ctx, cfg, be, log.New(os.Stderr))
+
+	repos, err := be.Repositories(ctx)
+	is.NoErr(err)
+	is.Equal(len(repos), 0)
+}
+
+func TestEnsureDefaultRepoCreatesWhenMissing(t *testing.T) {
+	is := is.New(t)
+	ctx, cfg, be := setupTestBackend(t)
+
+	cfg.DefaultRepo = "gitops"
+	ensureDefaultRepo(ctx, cfg, be, log.New(os.Stderr))
+
+	r, err := be.Repository(ctx, "gitops")
+	is.NoErr(err)
+	is.Equal(r.Name(), "gitops")
+	is.Equal(r.IsPrivate(), false)
+}
+
+func TestEnsureDefaultRepoIsIdempotent(t *testing.T) {
+	is := is.New(t)
+	ctx, cfg, be := setupTestBackend(t)
+
+	cfg.DefaultRepo = "gitops"
+	logger := log.New(os.Stderr)
+
+	ensureDefaultRepo(ctx, cfg, be, logger)
+	r, err := be.Repository(ctx, "gitops")
+	is.NoErr(err)
+	createdAt := r.CreatedAt()
+
+	// Restart-safety: a second boot against the same data must not error or
+	// touch the existing repository.
+	ensureDefaultRepo(ctx, cfg, be, logger)
+
+	r, err = be.Repository(ctx, "gitops")
+	is.NoErr(err)
+	is.Equal(r.CreatedAt(), createdAt)
+
+	repos, err := be.Repositories(ctx)
+	is.NoErr(err)
+	is.Equal(len(repos), 1)
+}
+
+func TestEnsureDefaultRepoInvalidNameSkipped(t *testing.T) {
+	is := is.New(t)
+	ctx, cfg, be := setupTestBackend(t)
+
+	cfg.DefaultRepo = "../not valid!"
+	ensureDefaultRepo(ctx, cfg, be, log.New(os.Stderr))
+
+	repos, err := be.Repositories(ctx)
+	is.NoErr(err)
+	is.Equal(len(repos), 0)
+}
+
+func TestEnsureDefaultRepoLooksUpExisting(t *testing.T) {
+	is := is.New(t)
+	ctx, cfg, be := setupTestBackend(t)
+
+	owner, err := be.UserByID(ctx, 1)
+	is.NoErr(err)
+	_, err = be.CreateRepository(ctx, "gitops", owner, proto.RepositoryOptions{
+		Private: true,
+	})
+	is.NoErr(err)
+
+	cfg.DefaultRepo = "gitops"
+	ensureDefaultRepo(ctx, cfg, be, log.New(os.Stderr))
+
+	r, err := be.Repository(ctx, "gitops")
+	is.NoErr(err)
+	is.Equal(r.IsPrivate(), true)
+}
+
+func TestEnsureDefaultRepoOwnerLookupFailsSkipped(t *testing.T) {
+	is := is.New(t)
+	ctx, cfg, be := setupTestBackend(t)
+
+	// Delete the built-in admin account (ID 1) so UserByID cannot find it.
+	// ensureDefaultRepo must log and return, not panic.
+	is.NoErr(be.DeleteUser(ctx, "admin"))
+
+	cfg.DefaultRepo = "gitops"
+	ensureDefaultRepo(ctx, cfg, be, log.New(os.Stderr))
+
+	repos, err := be.Repositories(ctx)
+	is.NoErr(err)
+	is.Equal(len(repos), 0)
+}
+
+func TestEnsureDefaultRepoLookupErrorSkipped(t *testing.T) {
+	is := is.New(t)
+	ctx, cfg, be, dbx := setupTestBackendWithDB(t)
+
+	// Create the repo directory on disk so Repository() passes os.Stat,
+	// then close the DB so the lookup behind it fails with a non-not-found error.
+	repoDir := filepath.Join(cfg.DataPath, "repos", "gitops.git")
+	is.NoErr(os.MkdirAll(repoDir, os.ModePerm))
+	is.NoErr(dbx.Close())
+
+	cfg.DefaultRepo = "gitops"
+	ensureDefaultRepo(ctx, cfg, be, log.New(os.Stderr))
+
+	_, err := be.UserByID(ctx, 1)
+	is.True(err != nil) // db is closed, sanity check we broke it correctly
+}
+
+func TestEnsureDefaultRepoCreateErrorSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("requires enforceable directory permissions as a non-root user")
+	}
+
+	is := is.New(t)
+	ctx, cfg, be := setupTestBackend(t)
+
+	// Make the "repos" directory read-only so CreateRepository's git.Init
+	// fails for a reason other than the repo already existing.
+	reposDir := filepath.Join(cfg.DataPath, "repos")
+	is.NoErr(os.MkdirAll(reposDir, os.ModePerm))
+	is.NoErr(os.Chmod(reposDir, 0o555))
+	t.Cleanup(func() { os.Chmod(reposDir, 0o755) }) //nolint: errcheck
+
+	cfg.DefaultRepo = "gitops"
+	ensureDefaultRepo(ctx, cfg, be, log.New(os.Stderr))
+
+	repos, err := be.Repositories(ctx)
+	is.NoErr(err)
+	is.Equal(len(repos), 0)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -191,6 +191,10 @@ type Config struct {
 	// A nil value means "no override": fall back to the database.
 	AllowKeyless *bool `env:"ALLOW_KEYLESS" yaml:"allow_keyless"`
 
+	// DefaultRepo is a repository name to create on boot if it does not
+	// already exist. Leave empty to disable.
+	DefaultRepo string `env:"DEFAULT_REPO" yaml:"default_repo"`
+
 	// DataPath is the path to the directory where Soft Serve will store its data.
 	DataPath string `env:"DATA_PATH" yaml:"-"`
 }
@@ -210,6 +214,7 @@ func (c *Config) Environ() []string {
 		fmt.Sprintf("SOFT_SERVE_DATA_PATH=%s", c.DataPath),
 		fmt.Sprintf("SOFT_SERVE_NAME=%s", c.Name),
 		fmt.Sprintf("SOFT_SERVE_INITIAL_ADMIN_KEYS=%s", strings.Join(c.InitialAdminKeys, "\n")),
+		fmt.Sprintf("SOFT_SERVE_DEFAULT_REPO=%s", c.DefaultRepo),
 		fmt.Sprintf("SOFT_SERVE_SSH_ENABLED=%t", c.SSH.Enabled),
 		fmt.Sprintf("SOFT_SERVE_SSH_LISTEN_ADDR=%s", c.SSH.ListenAddr),
 		fmt.Sprintf("SOFT_SERVE_SSH_PUBLIC_URL=%s", c.SSH.PublicURL),
@@ -378,7 +383,8 @@ func (c *Config) Exist() bool {
 // Use Validate() to validate the config and ensure absolute paths.
 func DefaultConfig() *Config {
 	return &Config{
-		Name:     "Soft Serve",
+		Name: "Soft Serve",
+		// DefaultRepo: "",
 		DataPath: DefaultDataPath(),
 		SSH: SSHConfig{
 			Enabled:       true,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -81,6 +81,29 @@ func TestCustomConfigLocation(t *testing.T) {
 	is.Equal(cfg.Name, "Soft Serve")
 }
 
+func TestDefaultRepoDisabledByDefault(t *testing.T) {
+	is := is.New(t)
+	is.Equal(DefaultConfig().DefaultRepo, "")
+}
+
+func TestParseDefaultRepo(t *testing.T) {
+	is := is.New(t)
+	is.NoErr(os.Setenv("SOFT_SERVE_DEFAULT_REPO", "gitops"))
+	t.Cleanup(func() {
+		is.NoErr(os.Unsetenv("SOFT_SERVE_DEFAULT_REPO"))
+	})
+	cfg := DefaultConfig()
+	is.NoErr(cfg.ParseEnv())
+	is.Equal(cfg.DefaultRepo, "gitops")
+}
+
+func TestParseDefaultRepoFromFile(t *testing.T) {
+	is := is.New(t)
+	cfg := &Config{DataPath: t.TempDir()}
+	is.NoErr(parseFile(cfg, "testdata/config_default_repo.yaml"))
+	is.Equal(cfg.DefaultRepo, "gitops")
+}
+
 func TestParseMultipleHeaders(t *testing.T) {
 	is := is.New(t)
 	is.NoErr(os.Setenv("SOFT_SERVE_HTTP_CORS_ALLOWED_HEADERS", "Accept,Accept-Language,User-Agent"))

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -147,6 +147,10 @@ jobs:
 # Additional admin keys.
 #initial_admin_keys:
 #  - "ssh-rsa AAAAB3NzaC1yc2..."
+
+# Name of a repository to create automatically on boot if it doesn't already
+# exist. Empty disables this behavior.
+#default_repo: ""
 `))
 
 func newConfigFile(cfg *Config) string {

--- a/pkg/config/testdata/config_default_repo.yaml
+++ b/pkg/config/testdata/config_default_repo.yaml
@@ -1,0 +1,4 @@
+# Soft Serve Server configurations
+
+name: "Test server name"
+default_repo: "gitops"

--- a/testscript/testdata/default-repo.txtar
+++ b/testscript/testdata/default-repo.txtar
@@ -1,0 +1,35 @@
+# vi: set ft=conf
+
+env SOFT_SERVE_DEFAULT_REPO=gitops
+
+# start soft serve, with no prior `repo create` call for the default repo,
+# and no anon-access overrides -- just an ordinary seeded admin key
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# the default repo must exist and be clonable with zero manual setup
+soft repo list
+stdout 'gitops'
+
+git clone ssh://localhost:$SSH_PORT/gitops gitops
+mkfile ./gitops/README.md '# gitops'
+git -C gitops add -A
+git -C gitops commit -m 'first'
+git -C gitops push origin HEAD
+
+# restart-safety: booting again against the same data dir must not error,
+# duplicate, or reset the repo's content
+stopserver
+ensureservernotrunning SSH_PORT
+exec soft serve &
+ensureserverrunning SSH_PORT
+
+soft repo list
+stdout 'gitops'
+
+git clone ssh://localhost:$SSH_PORT/gitops gitops2
+grep '# gitops' gitops2/README.md
+
+# stop the server
+[windows] stopserver


### PR DESCRIPTION
Adds a `default_repo` config option (`SOFT_SERVE_DEFAULT_REPO` env var) that creates a named repository automatically on boot if it doesn't already exist.

This is useful for GitOps tooling like ArgoCD that needs a git remote to point at as part of its own bootstrap, with no human available to run `repo create` after the server comes up.

- The repo is created empty and public, same as `repo create NAME` with no flags.
- Creation is idempotent: booting again against the same data directory is a no-op if the repo already exists.
- Invalid names or creation errors are logged and skipped rather than failing startup.

Tests: unit coverage for config parsing and the create-if-missing logic (including restart safety), plus an integration test that boots the server with the option set and confirms the repo is clonable immediately, with no prior `repo create` call.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created a discussion that was approved by a maintainer (for new features).
